### PR TITLE
Fix the fixes for 23.10 from 3 weeks ago

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -179,10 +179,7 @@ class QuizletWindow(QWidget):
         self.label_url = QLabel("Quizlet URL:")
         self.text_url = QLineEdit("", self)
         self.text_url.setMinimumWidth(300)
-
-        if hasattr(Qt, "StrongFocus"):
-            self.text_url.setFocusPolicy(Qt.StrongFocus)
-
+        self.text_url.setFocusPolicy(Qt.FocusPolicy.StrongFocus)
         self.text_url.setFocus()
 
         self.label_url.setMinimumWidth(100)
@@ -276,10 +273,7 @@ class QuizletWindow(QWidget):
 
         # go, baby go!
         self.setMinimumWidth(400)
-
-        if hasattr(QSizePolicy, "Minimum"):
-            self.setSizePolicy(QSizePolicy.Minimum, QSizePolicy.Minimum)
-
+        self.setSizePolicy(QSizePolicy.Policy.Minimum, QSizePolicy.Policy.Minimum)
         self.setWindowTitle("Improved Quizlet to Anki Importer")
         self.show()
 


### PR DESCRIPTION
https://forums.ankiweb.net/t/porting-tips-for-anki-23-10/35916 ("Qt6 requires enums to be prefixed with their type name.") The old way no longer works, as of Anki 23.10. The new way is backwards compatible.

https://doc.qt.io/qt-6/qt.html
https://doc.qt.io/qt-6/qsizepolicy.html

I don't use Quizlet, so I can't really test this add-on to see if there are any other issues.