### PR TITLE
perf: Integrate tls_requests package usage

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -693,8 +693,6 @@ class QuizletDownloader(QThread):
                 if self.quizletDeckID == 'folder':
                     url = self.url if proxyRetry else 'https://quizlet-proxy.proto.click/quizlet-folders?url=' + \
                         urllib.parse.quote(self.url, safe='()*!\'')
-
-                    #r = requests.get(url, verify=False, headers=headers, cookies=cookies)
                     r = tls_get(url, tls_identifier=TLS_IDENTIFIER, headers=headers, cookies=cookies)
                     r.raise_for_status()
                     page_html = r.text
@@ -706,7 +704,6 @@ class QuizletDownloader(QThread):
                         url = self.url if proxyRetry else 'https://quizlet-proxy.proto.click/quizlet-deck?url=' + \
                             urllib.parse.quote(self.url, safe='()*!\'')
                         print(url)
-                        #r = requests.get(url, verify=False, headers=headers, cookies=cookies)
                         r = tls_get(url, tls_identifier=TLS_IDENTIFIER, headers=headers, cookies=cookies)
                         r.raise_for_status()
                         page_html = r.text

--- a/build.sh
+++ b/build.sh
@@ -2,7 +2,7 @@
 
 rm -rf ./build \
 && mkdir build \
-&& cp __init__.py config.json meta.json manifest.json ./build \
+&& -r cp __init__.py vendor config.json meta.json manifest.json ./build \
 && cd build \
 && zip -r ../quizlet_importer.ankiaddon * \
 && cd ../ \

--- a/vendor/tls_requests/LICENSE.txt
+++ b/vendor/tls_requests/LICENSE.txt
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2024 thewebscraping
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/vendor/tls_requests/__init__.py
+++ b/vendor/tls_requests/__init__.py
@@ -1,0 +1,45 @@
+from .__version__ import __description__, __title__, __version__
+from .api import *
+from .client import *
+from .exceptions import *
+from .models import *
+from .settings import *
+from .types import *
+
+__all__ = [
+    "__version__",
+    "__author__",
+    "__title__",
+    "__description__",
+    "AsyncClient",
+    "Client",
+    "Cookies",
+    "CustomTLSClientConfig",
+    "Headers",
+    "Proxy",
+    "Request",
+    "Response",
+    "StatusCodes",
+    "TLSClient",
+    "TLSConfig",
+    "TLSLibrary",
+    "TLSResponse",
+    "URL",
+    "URLParams",
+    "delete",
+    "get",
+    "head",
+    "options",
+    "patch",
+    "post",
+    "put",
+]
+
+from .api import request
+
+__all__ += ["request"]
+
+__locals = locals()
+for __name in __all__:
+    if not __name.startswith("__"):
+        setattr(__locals[__name], "__module__", "tls_requests")  # noqa

--- a/vendor/tls_requests/__version__.py
+++ b/vendor/tls_requests/__version__.py
@@ -1,0 +1,7 @@
+__title__ = "wrapper-tls-requests"
+__description__ = "A powerful and lightweight Python library for making secure and reliable HTTP/TLS fingerprint requests."
+__url__ = "https://github.com/thewebscraping/tls-requests"
+__version__ = "1.1.8"
+__author__ = "Tu Pham"
+__author_email__ = "thetwofarm@gmail.com"
+__license__ = "MIT"

--- a/vendor/tls_requests/api.py
+++ b/vendor/tls_requests/api.py
@@ -1,0 +1,386 @@
+from __future__ import annotations
+
+import typing
+
+from .client import Client
+from .models import Response
+from .settings import (DEFAULT_FOLLOW_REDIRECTS, DEFAULT_TIMEOUT,
+                       DEFAULT_TLS_HTTP2, DEFAULT_TLS_IDENTIFIER)
+from .types import (AuthTypes, CookieTypes, HeaderTypes, MethodTypes,
+                    ProtocolTypes, ProxyTypes, RequestData, RequestFiles,
+                    TimeoutTypes, TLSIdentifierTypes, URLParamTypes, URLTypes)
+
+__all__ = [
+    "delete",
+    "get",
+    "head",
+    "options",
+    "patch",
+    "post",
+    "put",
+    "request",
+]
+
+
+def request(
+    method: MethodTypes,
+    url: URLTypes,
+    *,
+    params: URLParamTypes = None,
+    data: RequestData = None,
+    files: RequestFiles = None,
+    json: typing.Any = None,
+    headers: HeaderTypes = None,
+    cookies: CookieTypes = None,
+    auth: AuthTypes = None,
+    proxy: ProxyTypes = None,
+    http2: ProtocolTypes = DEFAULT_TLS_HTTP2,
+    timeout: TimeoutTypes = DEFAULT_TIMEOUT,
+    follow_redirects: bool = DEFAULT_FOLLOW_REDIRECTS,
+    verify: bool = True,
+    tls_identifier: TLSIdentifierTypes = DEFAULT_TLS_IDENTIFIER,
+    **config,
+) -> Response:
+    """
+        Constructs and sends an HTTP request.
+
+        This method builds a `Request` object based on the given parameters, sends
+        it using the configured client, and returns the server's response.
+
+        Parameters:
+            - **method** (str): HTTP method to use (e.g., `"GET"`, `"POST"`).
+            - **url** (URLTypes): The URL to send the request to.
+            - **params** (optional): Query parameters to include in the request URL.
+            - **data** (optional): Form data to include in the request body.
+            - **json** (optional): A JSON serializable object to include in the request body.
+            - **headers** (optional): Custom headers to include in the request.
+            - **cookies** (optional): Cookies to include with the request.
+            - **files** (optional): Files to upload in a multipart request.
+            - **auth** (optional): Authentication credentials or handler.
+            - **timeout** (optional): Timeout configuration for the request.
+            - **follow_redirects** (optional): Whether to follow HTTP redirects.
+
+        Returns:
+            - **Response**: The client's response to the HTTP request.
+
+        Usage:
+            ```python
+
+    import tls_requests
+                >>> with tls_requests.Client() as sync_client:
+                        r = sync_client.request('GET', 'https://httpbin.org/get')
+                >>> r
+                <Response [200]>
+            ```
+    """
+
+    with Client(
+        cookies=cookies,
+        proxy=proxy,
+        http2=http2,
+        timeout=timeout,
+        verify=verify,
+        client_identifier=tls_identifier,
+        **config,
+    ) as client:
+        return client.request(
+            method=method,
+            url=url,
+            data=data,
+            files=files,
+            json=json,
+            params=params,
+            headers=headers,
+            auth=auth,
+            follow_redirects=follow_redirects,
+            timeout=timeout,
+        )
+
+
+def get(
+    url: URLTypes,
+    *,
+    params: URLParamTypes = None,
+    headers: HeaderTypes = None,
+    cookies: CookieTypes = None,
+    auth: AuthTypes = None,
+    proxy: ProxyTypes = None,
+    http2: ProtocolTypes = DEFAULT_TLS_HTTP2,
+    timeout: TimeoutTypes = DEFAULT_TIMEOUT,
+    follow_redirects: bool = DEFAULT_FOLLOW_REDIRECTS,
+    verify: bool = True,
+    tls_identifier: TLSIdentifierTypes = DEFAULT_TLS_IDENTIFIER,
+    **config,
+) -> Response:
+    """
+    Sends a `GET` request.
+
+    **Parameters**: See `tls_requests.request`.
+
+    Note that the `data`, `files`, `json` and `content` parameters are not available
+    on this function, as `GET` requests should not include a request body.
+    """
+    return request(
+        "GET",
+        url,
+        params=params,
+        headers=headers,
+        cookies=cookies,
+        auth=auth,
+        proxy=proxy,
+        http2=http2,
+        follow_redirects=follow_redirects,
+        timeout=timeout,
+        verify=verify,
+        tls_identifier=tls_identifier,
+        **config,
+    )
+
+
+def options(
+    url: URLTypes,
+    *,
+    params: URLParamTypes = None,
+    headers: HeaderTypes = None,
+    cookies: CookieTypes = None,
+    auth: AuthTypes = None,
+    proxy: ProxyTypes = None,
+    http2: ProtocolTypes = DEFAULT_TLS_HTTP2,
+    timeout: TimeoutTypes = DEFAULT_TIMEOUT,
+    follow_redirects: bool = DEFAULT_FOLLOW_REDIRECTS,
+    verify: bool = True,
+    tls_identifier: TLSIdentifierTypes = DEFAULT_TLS_IDENTIFIER,
+    **config,
+) -> Response:
+    """
+    Sends an `OPTIONS` request.
+
+    **Parameters**: See `tls_requests.request`.
+
+    Note that the `data`, `files`, `json` and `content` parameters are not available
+    on this function, as `OPTIONS` requests should not include a request body.
+    """
+    return request(
+        "OPTIONS",
+        url,
+        params=params,
+        headers=headers,
+        cookies=cookies,
+        auth=auth,
+        proxy=proxy,
+        http2=http2,
+        follow_redirects=follow_redirects,
+        timeout=timeout,
+        verify=verify,
+        tls_identifier=tls_identifier,
+        **config,
+    )
+
+
+def head(
+    url: URLTypes,
+    *,
+    params: URLParamTypes = None,
+    headers: HeaderTypes = None,
+    cookies: CookieTypes = None,
+    auth: AuthTypes = None,
+    proxy: ProxyTypes = None,
+    http2: ProtocolTypes = DEFAULT_TLS_HTTP2,
+    timeout: TimeoutTypes = DEFAULT_TIMEOUT,
+    follow_redirects: bool = DEFAULT_FOLLOW_REDIRECTS,
+    verify: bool = True,
+    tls_identifier: TLSIdentifierTypes = DEFAULT_TLS_IDENTIFIER,
+    **config,
+) -> Response:
+    """
+    Sends a `HEAD` request.
+
+    **Parameters**: See `tls_requests.request`.
+
+    Note that the `data`, `files`, `json` and `content` parameters are not available
+    on this function, as `HEAD` requests should not include a request body.
+    """
+    return request(
+        "HEAD",
+        url,
+        params=params,
+        headers=headers,
+        cookies=cookies,
+        auth=auth,
+        proxy=proxy,
+        http2=http2,
+        timeout=timeout,
+        follow_redirects=follow_redirects,
+        verify=verify,
+        tls_identifier=tls_identifier,
+        **config,
+    )
+
+
+def post(
+    url: URLTypes,
+    *,
+    data: RequestData = None,
+    files: RequestFiles = None,
+    json: typing.Any = None,
+    params: URLParamTypes = None,
+    headers: HeaderTypes = None,
+    cookies: CookieTypes = None,
+    auth: AuthTypes = None,
+    proxy: ProxyTypes = None,
+    http2: ProtocolTypes = DEFAULT_TLS_HTTP2,
+    timeout: TimeoutTypes = DEFAULT_TIMEOUT,
+    follow_redirects: bool = DEFAULT_FOLLOW_REDIRECTS,
+    verify: bool = True,
+    tls_identifier: TLSIdentifierTypes = DEFAULT_TLS_IDENTIFIER,
+    **config,
+) -> Response:
+    """
+    Sends a `POST` request.
+
+    **Parameters**: See `tls_requests.request`.
+    """
+    return request(
+        "POST",
+        url,
+        data=data,
+        files=files,
+        json=json,
+        params=params,
+        headers=headers,
+        cookies=cookies,
+        auth=auth,
+        proxy=proxy,
+        http2=http2,
+        timeout=timeout,
+        follow_redirects=follow_redirects,
+        verify=verify,
+        tls_identifier=tls_identifier,
+        **config,
+    )
+
+
+def put(
+    url: URLTypes,
+    *,
+    data: RequestData = None,
+    files: RequestFiles = None,
+    json: typing.Any = None,
+    params: URLParamTypes = None,
+    headers: HeaderTypes = None,
+    cookies: CookieTypes = None,
+    auth: AuthTypes = None,
+    proxy: ProxyTypes = None,
+    http2: ProtocolTypes = DEFAULT_TLS_HTTP2,
+    timeout: TimeoutTypes = DEFAULT_TIMEOUT,
+    follow_redirects: bool = DEFAULT_FOLLOW_REDIRECTS,
+    verify: bool = True,
+    tls_identifier: TLSIdentifierTypes = DEFAULT_TLS_IDENTIFIER,
+    **config,
+) -> Response:
+    """
+    Sends a `PUT` request.
+
+    **Parameters**: See `tls_requests.request`.
+    """
+    return request(
+        "PUT",
+        url,
+        data=data,
+        files=files,
+        json=json,
+        params=params,
+        headers=headers,
+        cookies=cookies,
+        auth=auth,
+        proxy=proxy,
+        http2=http2,
+        timeout=timeout,
+        follow_redirects=follow_redirects,
+        verify=verify,
+        tls_identifier=tls_identifier,
+        **config,
+    )
+
+
+def patch(
+    url: URLTypes,
+    *,
+    data: RequestData = None,
+    files: RequestFiles = None,
+    json: typing.Any = None,
+    params: URLParamTypes = None,
+    headers: HeaderTypes = None,
+    cookies: CookieTypes = None,
+    auth: AuthTypes = None,
+    proxy: ProxyTypes = None,
+    http2: ProtocolTypes = DEFAULT_TLS_HTTP2,
+    timeout: TimeoutTypes = DEFAULT_TIMEOUT,
+    follow_redirects: bool = DEFAULT_FOLLOW_REDIRECTS,
+    verify: bool = True,
+    tls_identifier: TLSIdentifierTypes = DEFAULT_TLS_IDENTIFIER,
+    **config,
+) -> Response:
+    """
+    Sends a `PATCH` request.
+
+    **Parameters**: See `tls_requests.request`.
+    """
+    return request(
+        "PATCH",
+        url,
+        data=data,
+        files=files,
+        json=json,
+        params=params,
+        headers=headers,
+        cookies=cookies,
+        auth=auth,
+        proxy=proxy,
+        http2=http2,
+        timeout=timeout,
+        follow_redirects=follow_redirects,
+        verify=verify,
+        tls_identifier=tls_identifier,
+        **config,
+    )
+
+
+def delete(
+    url: URLTypes,
+    *,
+    params: URLParamTypes | None = None,
+    headers: HeaderTypes | None = None,
+    cookies: CookieTypes | None = None,
+    auth: AuthTypes | None = None,
+    proxy: ProxyTypes = None,
+    http2: ProtocolTypes = DEFAULT_TLS_HTTP2,
+    timeout: TimeoutTypes = DEFAULT_TIMEOUT,
+    follow_redirects: bool = DEFAULT_FOLLOW_REDIRECTS,
+    verify: bool = True,
+    tls_identifier: TLSIdentifierTypes = DEFAULT_TLS_IDENTIFIER,
+    **config,
+) -> Response:
+    """
+    Sends a `DELETE` request.
+
+    **Parameters**: See `tls_requests.request`.
+
+    Note that the `data`, `files`, `json` and `content` parameters are not available
+    on this function, as `DELETE` requests should not include a request body.
+    """
+    return request(
+        "DELETE",
+        url,
+        params=params,
+        headers=headers,
+        cookies=cookies,
+        auth=auth,
+        proxy=proxy,
+        http2=http2,
+        timeout=timeout,
+        follow_redirects=follow_redirects,
+        verify=verify,
+        tls_identifier=tls_identifier,
+        **config,
+    )

--- a/vendor/tls_requests/client.py
+++ b/vendor/tls_requests/client.py
@@ -1,0 +1,1128 @@
+from __future__ import annotations
+
+import datetime
+import time
+import typing
+import uuid
+from enum import Enum
+from typing import (Any, Callable, Literal, Mapping, Optional, Sequence,
+                    TypeVar, Union)
+
+from .exceptions import ProxyError, RemoteProtocolError, TooManyRedirects
+from .models import (URL, Auth, BasicAuth, Cookies, HeaderRotator, Headers,
+                     Proxy, ProxyRotator, Request, Response, StatusCodes,
+                     TLSClient, TLSConfig, TLSIdentifierRotator, URLParams)
+from .settings import (DEFAULT_FOLLOW_REDIRECTS, DEFAULT_HEADERS,
+                       DEFAULT_MAX_REDIRECTS, DEFAULT_TIMEOUT,
+                       DEFAULT_TLS_HTTP2, DEFAULT_TLS_IDENTIFIER)
+from .types import (AuthTypes, CookieTypes, HeaderTypes, HookTypes,
+                    ProtocolTypes, ProxyTypes, RequestData, RequestFiles,
+                    TimeoutTypes, TLSIdentifierTypes, URLParamTypes, URLTypes)
+from .utils import get_logger
+
+__all__ = ["AsyncClient", "Client"]
+
+T = TypeVar("T", bound="Client")
+A = TypeVar("A", bound="AsyncClient")
+
+
+logger = get_logger("TLSRequests")
+
+
+class ProtocolType(str, Enum):
+    AUTO = "auto"
+    HTTP1 = "http1"
+    HTTP2 = "http2"
+
+
+class ClientState(int, Enum):
+    UNOPENED = 1
+    OPENED = 2
+    CLOSED = 3
+
+
+class BaseClient:
+    """
+    A TLS-enabled HTTP client supporting advanced configuration options, including headers, cookies,
+    URL parameters, and proxy settings. It provides seamless HTTP/1.1 and HTTP/2 support with optional
+    authentication and robust redirect handling.
+
+    Attributes:
+        auth (Optional[AuthTypes]): Authentication options (e.g., tuples for basic auth, callable objects).
+        params (Optional[URLParamTypes]): URL parameters to include in requests.
+        headers (Optional[HeaderTypes]): Default headers for all requests.
+        cookies (Optional[CookieTypes]): Default cookies for all requests.
+        proxy (Optional[ProxyTypes]): Proxy configurations (e.g., proxy URL or instance).
+        timeout (Optional[float | int]): Timeout for requests, in seconds.
+        follow_redirects (bool): Whether to automatically follow redirects.
+        max_redirects (int): Maximum number of redirects allowed.
+        http2 (Optional[ProtocolTypes]): Specifies protocol options (e.g., 'auto', 'http1', 'http2', True, False, None).
+        verify (bool): Whether to verify TLS certificates.
+        client_identifier (Optional[TLSIdentifierTypes]): Identifier to emulate specific clients.
+        encoding (str): Default encoding for response decoding.
+
+    Methods:
+        build_request: Constructs and returns a `Request` instance with provided parameters.
+        prepare_headers: Merges default and custom headers for a request.
+        prepare_cookies: Merges default and custom cookies for a request.
+        prepare_params: Merges default and custom URL parameters for a request.
+        prepare_config: Prepares TLS and other configurations for sending a request.
+        close: Closes the client session and cleans up resources.
+
+    Properties:
+        - `session`: Returns the underlying TLS session object.
+        - `config`: Returns the current configuration.
+        - `is_closed`: Indicates if the client is closed.
+        - `headers`, `cookies`, `params`: Manage default headers, cookies, and parameters.
+
+    Lifecycle Management:
+        - Use the `BaseClient` within a context manager to ensure proper resource cleanup.
+        - Methods `__enter__` and `__exit__` handle opening and closing sessions automatically.
+    """
+
+    def __init__(
+        self,
+        *,
+        auth: AuthTypes = None,
+        params: URLParamTypes = None,
+        headers: HeaderTypes = None,
+        cookies: CookieTypes = None,
+        proxy: ProxyTypes = None,
+        timeout: TimeoutTypes = DEFAULT_TIMEOUT,
+        follow_redirects: bool = DEFAULT_FOLLOW_REDIRECTS,
+        max_redirects: int = DEFAULT_MAX_REDIRECTS,
+        http2: ProtocolTypes = DEFAULT_TLS_HTTP2,
+        verify: bool = True,
+        client_identifier: Optional[TLSIdentifierTypes] = DEFAULT_TLS_IDENTIFIER,
+        hooks: HookTypes = None,
+        encoding: str = "utf-8",
+        **config,
+    ) -> None:
+        self._session = TLSClient.initialize()
+        self._config = TLSConfig.from_kwargs(**config)
+        self._params = URLParams(params)
+        self._cookies = Cookies(cookies)
+        self._state = ClientState.UNOPENED
+        self._header_rotator: Optional[HeaderRotator] = None
+        self._headers: Headers = Headers()
+        if isinstance(headers, HeaderRotator):
+            self._header_rotator = headers
+        elif isinstance(headers, list):
+            self._header_rotator = HeaderRotator.from_file(headers)
+        elif headers is not None:
+            self._headers = Headers(headers)
+        self._hooks = hooks if isinstance(hooks, dict) else {}
+        self.auth = auth
+        self.proxy = ProxyRotator.from_file(proxy) if isinstance(proxy, list) else proxy
+        self.timeout = timeout
+        self.follow_redirects = follow_redirects
+        self.max_redirects = max_redirects
+        self.http2 = http2
+        self.verify = verify
+        self.client_identifier = (
+            TLSIdentifierRotator.from_file(client_identifier)
+            if isinstance(client_identifier, list)
+            else client_identifier
+        )
+        self.encoding = encoding
+
+    @property
+    def session(self) -> TLSClient:
+        return self._session
+
+    @property
+    def config(self) -> TLSConfig:
+        return self._config
+
+    @property
+    def closed(self) -> bool:
+        return bool(self._state == ClientState.CLOSED)
+
+    @property
+    def headers(self) -> Headers:
+        for k, v in DEFAULT_HEADERS.items():
+            if k not in self._headers:
+                self._headers[k] = v
+        return self._headers
+
+    @headers.setter
+    def headers(self, headers: HeaderTypes) -> None:
+        if isinstance(headers, HeaderRotator):
+            self._header_rotator = headers
+        elif isinstance(headers, list):
+            self._header_rotator = HeaderRotator.from_file(headers)
+        elif headers is not None:
+            self._headers = Headers(headers)
+
+    @property
+    def cookies(self) -> Cookies:
+        return self._cookies
+
+    @cookies.setter
+    def cookies(self, cookies: CookieTypes) -> None:
+        self._cookies = Cookies(cookies)
+
+    @property
+    def params(self) -> URLParams:
+        return self._params
+
+    @params.setter
+    def params(self, params: URLParamTypes) -> None:
+        self._params = URLParams(params)
+
+    @property
+    def hooks(self) -> Mapping[Literal["request", "response"], list[Callable]]:
+        return self._hooks
+
+    @hooks.setter
+    def hooks(self, hooks: HookTypes) -> None:
+        self._hooks = self._rebuild_hooks(hooks)
+
+    def prepare_auth(self, request: Request, auth: AuthTypes, *args, **kwargs) -> Union[Request, Any]:
+        """Build Auth Request instance"""
+
+        if isinstance(auth, tuple) and len(auth) == 2:
+            auth = BasicAuth(auth[0], auth[1])
+            return auth.build_auth(request)
+
+        if callable(auth):
+            return auth(request)
+
+        if isinstance(auth, Auth):
+            return auth.build_auth(request)
+
+        return auth
+
+    def prepare_headers(self, headers: HeaderTypes = None, user_agent: Optional[str] = None) -> Headers:
+        """Prepare Headers. Gets base headers from rotator if available."""
+        if headers is None:
+            return self.headers.copy()
+        if isinstance(headers, HeaderRotator):
+            return headers.next(user_agent=user_agent)
+        return Headers(headers)
+
+    def prepare_cookies(self, cookies: CookieTypes = None) -> Cookies:
+        """Prepare Cookies"""
+
+        merged_cookies = self.cookies.copy()
+        return merged_cookies.update(cookies)
+
+    def prepare_params(self, params: URLParamTypes = None) -> URLParams:
+        """Prepare URL Params"""
+
+        merged_params = self.params.copy()
+        return merged_params.update(params)
+
+    def prepare_proxy(self, proxy: ProxyTypes | None) -> Optional[Proxy]:
+        if proxy is None:
+            return None
+        if isinstance(proxy, ProxyRotator):
+            return proxy.next()
+        if isinstance(proxy, (str, bytes)):
+            return Proxy(proxy)
+        if isinstance(proxy, Proxy):
+            return proxy
+        if isinstance(proxy, URL):
+            return Proxy(str(proxy))
+        raise ProxyError(f"Unsupported proxy type: {type(proxy)}")
+
+    def prepare_tls_identifier(self, identifier: Optional[str, TLSIdentifierRotator]) -> str:
+        if isinstance(identifier, str):
+            return identifier
+        if isinstance(identifier, TLSIdentifierRotator):
+            return identifier.next()
+        return DEFAULT_TLS_IDENTIFIER
+
+    def prepare_config(self, request: Request, tls_identifier: str = DEFAULT_TLS_IDENTIFIER):
+        """Prepare TLS Config"""
+
+        config = self.config.copy_with(
+            method=request.method,
+            url=request.url,
+            body=request.read(),
+            headers=dict(request.headers),
+            cookies=[dict(name=k, value=v) for k, v in request.cookies.items()],
+            proxy=request.proxy.url if request.proxy else None,
+            timeout=request.timeout,
+            http2=True if self.http2 in ["auto", "http2", True, None] else False,
+            verify=self.verify,
+            tls_identifier=tls_identifier,
+        )
+
+        # Set Request SessionId.
+        request._session_id = config.sessionId
+        return config
+
+    def build_request(
+        self,
+        method: str,
+        url: URLTypes,
+        *,
+        data: RequestData = None,
+        files: RequestFiles = None,
+        json: typing.Any = None,
+        params: URLParamTypes = None,
+        headers: HeaderTypes = None,
+        cookies: CookieTypes = None,
+        timeout: TimeoutTypes = None,
+    ) -> Request:
+        """Build Request instance"""
+
+        return Request(
+            method,
+            url,
+            data=data,
+            files=files,
+            json=json,
+            params=self.prepare_params(params),
+            headers=self.prepare_headers(headers),
+            cookies=self.prepare_cookies(cookies),
+            proxy=self.prepare_proxy(self.proxy),
+            timeout=timeout or self.timeout,
+        )
+
+    def build_hook_request(self, request: Request, *args, **kwargs) -> Union[Request, Any]:
+        request_hooks = self._rebuild_hooks(self.hooks).get("request")
+        if isinstance(request_hooks, Sequence):
+            for hook in request_hooks:
+                if callable(hook):
+                    return hook(request)
+        return None
+
+    def build_hook_response(self, response: Response, *args, **kwargs) -> Union[Response, Any]:
+        request_hooks = self._rebuild_hooks(self.hooks).get("response")
+        if isinstance(request_hooks, Sequence):
+            for hook in request_hooks:
+                if callable(hook):
+                    return hook(response)
+        return None
+
+    def _rebuild_hooks(self, hooks: HookTypes):
+        if isinstance(hooks, dict):
+            return {
+                str(k).lower(): [func for func in items if callable(func)]
+                for k, items in hooks.items()
+                if str(k) in ["request", "response"] and isinstance(items, Sequence)
+            }
+        return None
+
+    def _rebuild_redirect_request(self, request: Request, response: Response) -> Request:
+        """Rebuild Redirect Request"""
+
+        return Request(
+            method=self._rebuild_redirect_method(request, response),
+            url=self._rebuild_redirect_url(request, response),
+            headers=request.headers,
+            cookies=response.cookies,
+        )
+
+    def _rebuild_redirect_method(self, request: Request, response: Response):
+        """Rebuild Redirect Method"""
+
+        method = request.method
+        if response.status_code == StatusCodes.SEE_OTHER and method != "HEAD":
+            method = "GET"
+
+        if response.status_code == StatusCodes.FOUND and method != "HEAD":
+            method = "GET"
+
+        if response.status_code == StatusCodes.MOVED_PERMANENTLY and method == "POST":
+            method = "GET"
+
+        return method
+
+    def _rebuild_redirect_url(self, request: Request, response: Response) -> URL:
+        """Rebuild Redirect URL"""
+
+        try:
+            url = URL(response.headers["Location"])
+        except KeyError:
+            raise RemoteProtocolError("Invalid URL in Location headers: %s" % e)
+
+        if not url.netloc:
+            for missing_field in ["scheme", "host", "port"]:
+                setattr(url, missing_field, getattr(request.url, missing_field, ""))
+
+        # TLS error transport between  HTTP/1.x -> HTTP/2
+        if url.scheme != request.url.scheme:
+            if request.url.scheme == "http":
+                url.scheme = request.url.scheme
+            else:
+                if self.http2 in ["auto", None]:
+                    self.session.destroy_session(self.config.sessionId)
+                    self.config.sessionId = str(uuid.uuid4())
+                else:
+                    raise RemoteProtocolError(
+                        "Switching remote scheme from HTTP/2 to HTTP/1 is not supported. Please initialize Client with"
+                        " parameter `http2` to `auto`."
+                    )
+
+        setattr(url, "_url", None)  # reset url
+        if not url.url:
+            raise RemoteProtocolError("Invalid URL in Location headers: %s" % e)
+
+        return url
+
+    def _send(self, request: Request, *, history: list = None, start: float = None) -> Response:
+        start = start or time.perf_counter()
+        tls_identifier = self.prepare_tls_identifier(self.client_identifier)
+        config = self.prepare_config(request, tls_identifier=tls_identifier)
+        response = Response.from_tls_response(
+            self.session.request(config.to_dict()),
+            is_byte_response=config.isByteResponse,
+        )
+        response.request = request
+        response.default_encoding = self.encoding
+        response.elapsed = datetime.timedelta(seconds=time.perf_counter() - start)
+        if response.is_redirect:
+            response.next = self._rebuild_redirect_request(response.request, response)
+            if self.follow_redirects:
+                is_break = bool(len(history) < self.max_redirects)
+                if not is_break:
+                    raise TooManyRedirects("Too many redirects.")
+
+                while is_break:
+                    history.append(response)
+                    return self._send(response.next, history=history, start=start)
+
+        response.history = history
+        return response
+
+    def close(self) -> None:
+        """Close TLS Client session."""
+
+        self.session.destroy_session(self.config.sessionId)
+        self._state = ClientState.CLOSED
+
+    def __enter__(self: T) -> T:
+        if self._state == ClientState.OPENED:
+            raise RuntimeError("It is not possible to open a client instance more than once.")
+
+        if self._state == ClientState.CLOSED:
+            raise RuntimeError("The client instance cannot be reopened after it has been closed.")
+
+        self._state = ClientState.OPENED
+        return self
+
+    def __exit__(self, *args, **kwargs) -> None:
+        self.close()
+
+
+class Client(BaseClient):
+    """
+    An HTTP client with advanced features such as connection pooling, HTTP/2 support,
+    automatic redirects, and cookie persistence.
+
+    This client is thread-safe and can be shared between threads for efficient HTTP
+    interactions in multi-threaded applications.
+
+    Usage:
+        ```python
+            >>> with tls_requests.AsyncClient(http2='auto', follow_redirects=True) as client:
+                    response = client.get('https://httpbin.org/get')
+                    response.raise_for_status()
+            >>> response
+            <Response [200]>
+        ```
+
+    Parameters:
+        - Inherits all parameters and configurations from `tls_requests.BaseClient`.
+    """
+
+    def request(
+        self,
+        method: str,
+        url: URLTypes,
+        *,
+        data: RequestData = None,
+        files: RequestFiles = None,
+        json: typing.Any = None,
+        params: URLParamTypes = None,
+        headers: HeaderTypes = None,
+        cookies: CookieTypes = None,
+        auth: AuthTypes = None,
+        follow_redirects: bool = DEFAULT_FOLLOW_REDIRECTS,
+        timeout: TimeoutTypes = DEFAULT_TIMEOUT,
+    ):
+        """
+        Constructs and sends an HTTP request.
+
+        This method builds a `Request` object based on the given parameters, sends
+        it using the configured client, and returns the server's response.
+
+        Parameters:
+            - **method** (str): HTTP method to use (e.g., `"GET"`, `"POST"`).
+            - **url** (URLTypes): The URL to send the request to.
+            - **params** (optional): Query parameters to include in the request URL.
+            - **data** (optional): Form data to include in the request body.
+            - **json** (optional): A JSON serializable object to include in the request body.
+            - **headers** (optional): Custom headers to include in the request.
+            - **cookies** (optional): Cookies to include with the request.
+            - **files** (optional): Files to upload in a multipart request.
+            - **auth** (optional): Authentication credentials or handler.
+            - **timeout** (optional): Timeout configuration for the request.
+            - **follow_redirects** (optional): Whether to follow HTTP redirects.
+
+        Returns:
+            - **Response**: The client's response to the HTTP request.
+
+        Usage:
+            ```python
+                >>> r = client.request('GET', 'https://httpbin.org/get')
+                >>> r
+                <Response [200]>
+            ```
+        """
+
+        request = self.build_request(
+            method=method,
+            url=url,
+            data=data,
+            files=files,
+            json=json,
+            params=params,
+            headers=headers,
+            cookies=cookies,
+            timeout=timeout,
+        )
+        return self.send(request, auth=auth, follow_redirects=follow_redirects)
+
+    def send(
+        self,
+        request: Request,
+        *,
+        auth: AuthTypes = None,
+        follow_redirects: bool = DEFAULT_FOLLOW_REDIRECTS,
+    ):
+        if self._state == ClientState.CLOSED:
+            raise RuntimeError("Cannot send a request, as the client has been closed.")
+
+        self._state = ClientState.OPENED
+        for fn in [self.prepare_auth, self.build_hook_request]:
+            request_ = fn(request, auth or self.auth, follow_redirects)
+            if isinstance(request_, Request):
+                request = request_
+
+        self.follow_redirects = follow_redirects
+        response = self._send(request, start=time.perf_counter(), history=[])
+
+        if isinstance(self.proxy, ProxyRotator) and response.request.proxy:
+            proxy_success = 200 <= response.status_code < 500 and response.status_code not in [407]
+            self.proxy.mark_result(
+                proxy=response.request.proxy,
+                success=proxy_success,
+                latency=response.elapsed,
+            )
+
+        if self.hooks.get("response"):
+            response_ = self.build_hook_response(response)
+            if isinstance(response_, Response):
+                response = response_
+        else:
+            response.read()
+
+        response.close()
+        return response
+
+    def get(
+        self,
+        url: URLTypes,
+        *,
+        params: URLParamTypes = None,
+        headers: HeaderTypes = None,
+        cookies: CookieTypes = None,
+        auth: AuthTypes = None,
+        follow_redirects: bool = DEFAULT_FOLLOW_REDIRECTS,
+        timeout: TimeoutTypes = DEFAULT_TIMEOUT,
+    ):
+        """
+        Send a `GET` request.
+
+        **Parameters**: See `tls_requests.request`.
+        """
+        return self.request(
+            "GET",
+            url,
+            params=params,
+            headers=headers,
+            cookies=cookies,
+            auth=auth,
+            follow_redirects=follow_redirects,
+            timeout=timeout,
+        )
+
+    def options(
+        self,
+        url: URLTypes,
+        *,
+        params: URLParamTypes = None,
+        headers: HeaderTypes = None,
+        cookies: CookieTypes = None,
+        auth: AuthTypes = None,
+        follow_redirects: bool = DEFAULT_FOLLOW_REDIRECTS,
+        timeout: TimeoutTypes = DEFAULT_TIMEOUT,
+    ) -> Response:
+        """
+        Send an `OPTIONS` request.
+
+        **Parameters**: See `tls_requests.request`.
+        """
+        return self.request(
+            "OPTIONS",
+            url,
+            params=params,
+            headers=headers,
+            cookies=cookies,
+            auth=auth,
+            follow_redirects=follow_redirects,
+            timeout=timeout,
+        )
+
+    def head(
+        self,
+        url: URLTypes,
+        *,
+        params: URLParamTypes = None,
+        headers: HeaderTypes = None,
+        cookies: CookieTypes = None,
+        auth: AuthTypes = None,
+        follow_redirects: bool = DEFAULT_FOLLOW_REDIRECTS,
+        timeout: TimeoutTypes = DEFAULT_TIMEOUT,
+    ) -> Response:
+        """
+        Send a `HEAD` request.
+
+        **Parameters**: See `tls_requests.request`.
+        """
+        return self.request(
+            "HEAD",
+            url,
+            params=params,
+            headers=headers,
+            cookies=cookies,
+            auth=auth,
+            follow_redirects=follow_redirects,
+            timeout=timeout,
+        )
+
+    def post(
+        self,
+        url: URLTypes,
+        *,
+        data: RequestData = None,
+        files: RequestFiles = None,
+        json: typing.Any = None,
+        params: URLParamTypes = None,
+        headers: HeaderTypes = None,
+        cookies: CookieTypes = None,
+        auth: AuthTypes = None,
+        follow_redirects: bool = DEFAULT_FOLLOW_REDIRECTS,
+        timeout: TimeoutTypes = DEFAULT_TIMEOUT,
+    ) -> Response:
+        """
+        Send a `POST` request.
+
+        **Parameters**: See `tls_requests.request`.
+        """
+        return self.request(
+            "POST",
+            url,
+            data=data,
+            files=files,
+            json=json,
+            params=params,
+            headers=headers,
+            cookies=cookies,
+            auth=auth,
+            follow_redirects=follow_redirects,
+            timeout=timeout,
+        )
+
+    def put(
+        self,
+        url: URLTypes,
+        *,
+        data: RequestData = None,
+        files: RequestFiles = None,
+        json: typing.Any = None,
+        params: URLParamTypes = None,
+        headers: HeaderTypes = None,
+        cookies: CookieTypes = None,
+        auth: AuthTypes = None,
+        follow_redirects: bool = DEFAULT_FOLLOW_REDIRECTS,
+        timeout: TimeoutTypes = DEFAULT_TIMEOUT,
+    ) -> Response:
+        """
+        Send a `PUT` request.
+
+        **Parameters**: See `tls_requests.request`.
+        """
+        return self.request(
+            "PUT",
+            url,
+            data=data,
+            files=files,
+            json=json,
+            params=params,
+            headers=headers,
+            cookies=cookies,
+            auth=auth,
+            follow_redirects=follow_redirects,
+            timeout=timeout,
+        )
+
+    def patch(
+        self,
+        url: URLTypes,
+        *,
+        data: RequestData = None,
+        files: RequestFiles = None,
+        json: typing.Any = None,
+        params: URLParamTypes = None,
+        headers: HeaderTypes = None,
+        cookies: CookieTypes = None,
+        auth: AuthTypes = None,
+        follow_redirects: bool = DEFAULT_FOLLOW_REDIRECTS,
+        timeout: TimeoutTypes = DEFAULT_TIMEOUT,
+    ) -> Response:
+        """
+        Send a `PATCH` request.
+
+        **Parameters**: See `tls_requests.request`.
+        """
+        return self.request(
+            "PATCH",
+            url,
+            data=data,
+            files=files,
+            json=json,
+            params=params,
+            headers=headers,
+            cookies=cookies,
+            auth=auth,
+            follow_redirects=follow_redirects,
+            timeout=timeout,
+        )
+
+    def delete(
+        self,
+        url: URLTypes,
+        *,
+        params: URLParamTypes = None,
+        headers: HeaderTypes = None,
+        cookies: CookieTypes = None,
+        auth: AuthTypes = None,
+        follow_redirects: bool = DEFAULT_FOLLOW_REDIRECTS,
+        timeout: TimeoutTypes = DEFAULT_TIMEOUT,
+    ) -> Response:
+        """
+        Send a `DELETE` request.
+
+        **Parameters**: See `tls_requests.request`.
+        """
+        return self.request(
+            "DELETE",
+            url,
+            params=params,
+            headers=headers,
+            cookies=cookies,
+            auth=auth,
+            follow_redirects=follow_redirects,
+            timeout=timeout,
+        )
+
+
+class AsyncClient(BaseClient):
+    """
+    An asynchronous HTTP client, with connection pooling, HTTP/2, redirects,
+    cookie persistence, etc.
+
+    It can be shared between tasks.
+
+    Usage:
+
+    ```python
+    >>> import asyncio
+    >>> async def fetch(url: str, params: URLParamTypes = None)
+            async with tls_requests.AsyncClient(http2='auto', follow_redirects=True) as client:
+                response = await client.get(url, params=params)
+                response.raise_for_status()
+                return response
+    >>> response = asyncio.run(fetch('https://httpbin.org/get'))
+    ```
+
+    **Parameters:** See `tls_requests.BaseClient`.
+    """
+
+    async def aprepare_headers(self, headers: HeaderTypes = None, user_agent: Optional[str] = None) -> Headers:
+        """Prepare Headers. Gets base headers from rotator if available."""
+        if headers is None:
+            return self.headers.copy()
+        if isinstance(headers, HeaderRotator):
+            return await headers.anext(user_agent=user_agent)
+        return Headers(headers)
+
+    async def aprepare_proxy(self, proxy: ProxyTypes | None) -> Optional[Proxy]:
+        if proxy is None:
+            return None
+        if isinstance(proxy, ProxyRotator):
+            return await proxy.anext()
+        if isinstance(proxy, (str, bytes)):
+            return Proxy(proxy)
+        if isinstance(proxy, Proxy):
+            return proxy
+        if isinstance(proxy, URL):
+            return Proxy(str(proxy))
+        raise ProxyError(f"Unsupported proxy type: {type(proxy)}")
+
+    async def aprepare_tls_identifier(self, identifier) -> str:
+        if isinstance(identifier, str):
+            return identifier
+        if isinstance(identifier, TLSIdentifierRotator):
+            return await identifier.anext()
+        return DEFAULT_TLS_IDENTIFIER
+
+    async def abuild_request(
+        self,
+        method: str,
+        url: URLTypes,
+        *,
+        data: RequestData = None,
+        files: RequestFiles = None,
+        json: typing.Any = None,
+        params: URLParamTypes = None,
+        headers: HeaderTypes = None,
+        cookies: CookieTypes = None,
+        timeout: TimeoutTypes = None,
+    ) -> Request:
+        headers = await self.aprepare_headers(headers)
+        proxy = await self.aprepare_proxy(self.proxy)
+        return Request(
+            method,
+            url,
+            data=data,
+            files=files,
+            json=json,
+            params=self.prepare_params(params),
+            headers=headers,
+            cookies=self.prepare_cookies(cookies),
+            proxy=proxy,
+            timeout=timeout or self.timeout,
+        )
+
+    async def request(
+        self,
+        method: str,
+        url: URLTypes,
+        *,
+        data: RequestData = None,
+        files: RequestFiles = None,
+        json: typing.Any = None,
+        params: URLParamTypes = None,
+        headers: HeaderTypes = None,
+        cookies: CookieTypes = None,
+        auth: AuthTypes = None,
+        follow_redirects: bool = DEFAULT_FOLLOW_REDIRECTS,
+        timeout: TimeoutTypes = DEFAULT_TIMEOUT,
+    ) -> Response:
+        """Async Request"""
+
+        request = await self.abuild_request(
+            method=method,
+            url=url,
+            data=data,
+            files=files,
+            json=json,
+            params=params,
+            headers=headers,
+            cookies=cookies,
+            timeout=timeout,
+        )
+        return await self.send(request, auth=auth, follow_redirects=follow_redirects)
+
+    async def get(
+        self,
+        url: URLTypes,
+        *,
+        params: URLParamTypes = None,
+        headers: HeaderTypes = None,
+        cookies: CookieTypes = None,
+        auth: AuthTypes = None,
+        follow_redirects: bool = DEFAULT_FOLLOW_REDIRECTS,
+        timeout: TimeoutTypes = DEFAULT_TIMEOUT,
+    ) -> Response:
+        """
+        Send a `GET` request.
+
+        **Parameters**: See `tls_requests.request`.
+        """
+        return await self.request(
+            "GET",
+            url,
+            params=params,
+            headers=headers,
+            cookies=cookies,
+            auth=auth,
+            follow_redirects=follow_redirects,
+            timeout=timeout,
+        )
+
+    async def options(
+        self,
+        url: URLTypes,
+        *,
+        params: URLParamTypes = None,
+        headers: HeaderTypes = None,
+        cookies: CookieTypes = None,
+        auth: AuthTypes = None,
+        follow_redirects: bool = DEFAULT_FOLLOW_REDIRECTS,
+        timeout: TimeoutTypes = DEFAULT_TIMEOUT,
+    ) -> Response:
+        """
+        Send an `OPTIONS` request.
+
+        **Parameters**: See `tls_requests.request`.
+        """
+        return await self.request(
+            "OPTIONS",
+            url,
+            params=params,
+            headers=headers,
+            cookies=cookies,
+            auth=auth,
+            follow_redirects=follow_redirects,
+            timeout=timeout,
+        )
+
+    async def head(
+        self,
+        url: URLTypes,
+        *,
+        params: URLParamTypes = None,
+        headers: HeaderTypes = None,
+        cookies: CookieTypes = None,
+        auth: AuthTypes = None,
+        follow_redirects: bool = DEFAULT_FOLLOW_REDIRECTS,
+        timeout: TimeoutTypes = DEFAULT_TIMEOUT,
+    ) -> Response:
+        """
+        Send a `HEAD` request.
+
+        **Parameters**: See `tls_requests.request`.
+        """
+        return await self.request(
+            "HEAD",
+            url,
+            params=params,
+            headers=headers,
+            cookies=cookies,
+            auth=auth,
+            follow_redirects=follow_redirects,
+            timeout=timeout,
+        )
+
+    async def post(
+        self,
+        url: URLTypes,
+        *,
+        data: RequestData = None,
+        files: RequestFiles = None,
+        json: typing.Any = None,
+        params: URLParamTypes = None,
+        headers: HeaderTypes = None,
+        cookies: CookieTypes = None,
+        auth: AuthTypes = None,
+        follow_redirects: bool = DEFAULT_FOLLOW_REDIRECTS,
+        timeout: TimeoutTypes = DEFAULT_TIMEOUT,
+    ) -> Response:
+        """
+        Send a `POST` request.
+
+        **Parameters**: See `tls_requests.request`.
+        """
+        return await self.request(
+            "POST",
+            url,
+            data=data,
+            files=files,
+            json=json,
+            params=params,
+            headers=headers,
+            cookies=cookies,
+            auth=auth,
+            follow_redirects=follow_redirects,
+            timeout=timeout,
+        )
+
+    async def put(
+        self,
+        url: URLTypes,
+        *,
+        data: RequestData = None,
+        files: RequestFiles = None,
+        json: typing.Any = None,
+        params: URLParamTypes = None,
+        headers: HeaderTypes = None,
+        cookies: CookieTypes = None,
+        auth: AuthTypes = None,
+        follow_redirects: bool = DEFAULT_FOLLOW_REDIRECTS,
+        timeout: TimeoutTypes = DEFAULT_TIMEOUT,
+    ) -> Response:
+        """
+        Send a `PUT` request.
+
+        **Parameters**: See `tls_requests.request`.
+        """
+        return await self.request(
+            "PUT",
+            url,
+            data=data,
+            files=files,
+            json=json,
+            params=params,
+            headers=headers,
+            cookies=cookies,
+            auth=auth,
+            follow_redirects=follow_redirects,
+            timeout=timeout,
+        )
+
+    async def patch(
+        self,
+        url: URLTypes,
+        *,
+        data: RequestData = None,
+        files: RequestFiles = None,
+        json: typing.Any = None,
+        params: URLParamTypes = None,
+        headers: HeaderTypes = None,
+        cookies: CookieTypes = None,
+        auth: AuthTypes = None,
+        follow_redirects: bool = DEFAULT_FOLLOW_REDIRECTS,
+        timeout: TimeoutTypes = DEFAULT_TIMEOUT,
+    ) -> Response:
+        """
+        Send a `PATCH` request.
+
+        **Parameters**: See `tls_requests.request`.
+        """
+        return await self.request(
+            "PATCH",
+            url,
+            data=data,
+            files=files,
+            json=json,
+            params=params,
+            headers=headers,
+            cookies=cookies,
+            auth=auth,
+            follow_redirects=follow_redirects,
+            timeout=timeout,
+        )
+
+    async def delete(
+        self,
+        url: URLTypes,
+        *,
+        params: URLParamTypes = None,
+        headers: HeaderTypes = None,
+        cookies: CookieTypes = None,
+        auth: AuthTypes = None,
+        follow_redirects: bool = DEFAULT_FOLLOW_REDIRECTS,
+        timeout: TimeoutTypes = DEFAULT_TIMEOUT,
+    ) -> Response:
+        """
+        Send a `DELETE` request.
+
+        **Parameters**: See `tls_requests.request`.
+        """
+        return await self.request(
+            "DELETE",
+            url,
+            params=params,
+            headers=headers,
+            cookies=cookies,
+            auth=auth,
+            follow_redirects=follow_redirects,
+            timeout=timeout,
+        )
+
+    async def send(
+        self,
+        request: Request,
+        *,
+        stream: bool = False,
+        auth: AuthTypes = None,
+        follow_redirects: bool = DEFAULT_FOLLOW_REDIRECTS,
+    ) -> Response:
+        if self._state == ClientState.CLOSED:
+            pass  # pass duplicated code
+            raise RuntimeError("Cannot send a request, as the client has been closed.")
+
+        self._state = ClientState.OPENED
+        for fn in [self.prepare_auth, self.build_hook_request]:
+            request_ = fn(request, auth or self.auth, follow_redirects)
+            if isinstance(request_, Request):
+                request = request_
+
+        self.follow_redirects = follow_redirects
+        response = await self._send(request, start=time.perf_counter(), history=[])
+
+        if isinstance(self.proxy, ProxyRotator) and response.request.proxy:
+            proxy_success = 200 <= response.status_code < 500 and response.status_code not in [407]
+            await self.proxy.amark_result(
+                proxy=response.request.proxy,
+                success=proxy_success,
+                latency=response.elapsed,
+            )
+
+        if self.hooks.get("response"):
+            response_ = self.build_hook_response(response)
+            if isinstance(response_, Response):
+                response = response_
+        else:
+            await response.aread()
+
+        await response.aclose()
+        return response
+
+    async def _send(self, request: Request, *, history: list = None, start: float = None) -> Response:
+        start = start or time.perf_counter()
+        tls_identifier = await self.aprepare_tls_identifier(self.client_identifier)
+        config = self.prepare_config(request, tls_identifier=tls_identifier)
+        response = Response.from_tls_response(
+            await self.session.arequest(config.to_dict()),
+            is_byte_response=config.isByteResponse,
+        )
+        response.request = request
+        response.default_encoding = self.encoding
+        response.elapsed = datetime.timedelta(seconds=time.perf_counter() - start)
+        if response.is_redirect:
+            response.next = self._rebuild_redirect_request(response.request, response)
+            if self.follow_redirects:
+                is_break = bool(len(history) < self.max_redirects)
+                if not is_break:
+                    raise TooManyRedirects("Too many redirects.")
+
+                while is_break:
+                    history.append(response)
+                    return await self._send(response.next, history=history, start=start)
+
+        response.history = history
+        return response
+
+    async def aclose(self) -> None:
+        return self.close()
+
+    async def __aenter__(self: A) -> A:
+        if self._state == ClientState.OPENED:
+            raise RuntimeError("It is not possible to open a client instance more than once.")
+
+        if self._state == ClientState.CLOSED:
+            raise RuntimeError("The client instance cannot be reopened after it has been closed.")
+
+        self._state = ClientState.OPENED
+        return self
+
+    async def __aexit__(self, *args, **kwargs) -> None:
+        await self.aclose()

--- a/vendor/tls_requests/exceptions.py
+++ b/vendor/tls_requests/exceptions.py
@@ -1,0 +1,98 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    pass
+
+__all__ = [
+    "AuthenticationError",
+    "CookieConflictError",
+    "HTTPError",
+    "HeaderError",
+    "ProtocolError",
+    "RemoteProtocolError",
+    "StreamConsumed",
+    "StreamError",
+    "TLSError",
+    "RotatorError",
+    "TooManyRedirects",
+    "URLError",
+]
+
+
+class HTTPError(Exception):
+    """HTTP Error"""
+
+    def __init__(self, message: str, **kwargs) -> None:
+        self.message = message
+        response = kwargs.pop("response", None)
+        self.response = response
+        self.request = kwargs.pop("request", None)
+        if response is not None and not self.request and hasattr(response, "request"):
+            self.request = self.response.request
+        super().__init__(message)
+
+
+class AuthenticationError(HTTPError):
+    """Authentication Error"""
+
+
+class HeaderError(HTTPError):
+    """Header Error"""
+
+
+class ProtocolError(HTTPError):
+    """Protocol Error"""
+
+
+class RemoteProtocolError(HTTPError):
+    """Remote Protocol Error"""
+
+
+class TooManyRedirects(HTTPError):
+    """Too Many Redirects."""
+
+
+class TLSError(HTTPError):
+    """TLS Error"""
+
+
+class Base64DecodeError(HTTPError):
+    """Base64 Decode Error"""
+
+
+class URLError(HTTPError):
+    pass
+
+
+class ProxyError(HTTPError):
+    pass
+
+
+class URLParamsError(URLError):
+    pass
+
+
+class CookieError(HTTPError):
+    pass
+
+
+class CookieConflictError(CookieError):
+    pass
+
+
+class StreamError(HTTPError):
+    pass
+
+
+class StreamConsumed(StreamError):
+    pass
+
+
+class StreamClosed(StreamError):
+    pass
+
+
+class RotatorError(HTTPError):
+    pass

--- a/vendor/tls_requests/models/__init__.py
+++ b/vendor/tls_requests/models/__init__.py
@@ -1,0 +1,13 @@
+from .auth import Auth, BasicAuth
+from .cookies import Cookies
+from .encoders import (JsonEncoder, MultipartEncoder, StreamEncoder,
+                       UrlencodedEncoder)
+from .headers import Headers
+from .libraries import TLSLibrary
+from .request import Request
+from .response import Response
+from .rotators import (BaseRotator, HeaderRotator, ProxyRotator,
+                       TLSIdentifierRotator)
+from .status_codes import StatusCodes
+from .tls import CustomTLSClientConfig, TLSClient, TLSConfig, TLSResponse
+from .urls import URL, Proxy, URLParams

--- a/vendor/tls_requests/models/auth.py
+++ b/vendor/tls_requests/models/auth.py
@@ -1,0 +1,36 @@
+from base64 import b64encode
+from typing import Any, Union
+
+from ..exceptions import AuthenticationError
+from .request import Request
+
+
+class Auth:
+    """Base Auth"""
+
+    def build_auth(self, request: Request) -> Union[Request, Any]:
+        pass
+
+
+class BasicAuth(Auth):
+    """Basic Authentication"""
+
+    def __init__(self, username: Union[str, bytes], password: Union[str, bytes]):
+        self.username = username
+        self.password = password
+
+    def build_auth(self, request: Request):
+        return self._build_auth_headers(request)
+
+    def _build_auth_headers(self, request: Request):
+        auth_token = b64encode(b":".join([self._encode(self.username), self._encode(self.password)])).decode()
+        request.headers["Authorization"] = "Basic %s" % auth_token
+
+    def _encode(self, value: Union[str, bytes]) -> bytes:
+        if isinstance(self.username, str):
+            value = value.encode("latin1")
+
+        if not isinstance(value, bytes):
+            raise AuthenticationError("`username` or `password` parameter must be str or byte.")
+
+        return value

--- a/vendor/tls_requests/models/cookies.py
+++ b/vendor/tls_requests/models/cookies.py
@@ -1,0 +1,610 @@
+# Origin: requests library (https://github.com/psf/requests)
+
+from __future__ import annotations
+
+import copy
+from email.message import Message
+from http import cookiejar as cookielib
+from http.cookiejar import Cookie
+from http.cookies import Morsel
+from typing import TYPE_CHECKING, Iterator, MutableMapping, Optional
+from urllib.parse import urlparse, urlunparse
+
+from ..exceptions import CookieConflictError, CookieError
+from ..types import CookieTypes
+
+if TYPE_CHECKING:
+    from .request import Request
+    from .response import Response
+
+
+__all__ = ["Cookies"]
+
+
+class MockResponse:
+    def __init__(self, response: Response):
+        self._original_response = response
+
+    def info(self):
+        info = Message()
+        for k, v in self._original_response.headers.items():
+            info[k] = v
+        return info
+
+
+class MockRequest:
+
+    def __init__(self, request: Request):
+        self._new_headers = {}
+        self._request = request
+        self._headers = request.headers
+        self.type = urlparse(str(request.url)).scheme
+
+    def get_type(self):
+        return self.type
+
+    def get_host(self):
+        return urlparse(str(self._request.url)).netloc
+
+    def get_origin_req_host(self):
+        return self.get_host()
+
+    def get_full_url(self):
+        # Only return the response's URL if the user hadn't set the Host
+        # header
+        if not self._headers.get("Host"):
+            return str(self._request.url)
+
+        # If they did set it, retrieve it and reconstruct the expected domain
+        host = self._headers["Host"]
+        parsed = urlparse(self.request_url)
+        # Reconstruct the URL as we expect it
+        return urlunparse(
+            [
+                parsed.scheme,
+                host,
+                parsed.path,
+                parsed.params,
+                parsed.query,
+                parsed.fragment,
+            ]
+        )
+
+    def is_unverifiable(self):
+        return True
+
+    def has_header(self, name):
+        return name in self._headers or name in self._new_headers
+
+    def get_header(self, name, default=None):
+        return self._headers.get(name, self._new_headers.get(name, default))
+
+    def add_unredirected_header(self, name, value):
+        self._new_headers[name] = value
+
+    def get_new_headers(self):
+        return self._new_headers
+
+    @property
+    def unverifiable(self):
+        return self.is_unverifiable()
+
+    @property
+    def origin_req_host(self):
+        return self.get_origin_req_host()
+
+    @property
+    def host(self):
+        return self.get_host()
+
+
+class RequestsCookieJar(cookielib.CookieJar, MutableMapping):
+    """Compatibility class; is a http.cookiejar.CookieJar, but exposes a dict
+    interface.
+
+    This is the CookieJar we create by default for requests and sessions that
+    don't specify one, since some clients may expect response.cookies and
+    session.cookies to support dict operations.
+
+    Requests does not use the dict interface internally; it's just for
+    compatibility with external client code. All requests code should work
+    out of the box with externally provided instances of ``CookieJar``, e.g.
+    ``LWPCookieJar`` and ``FileCookieJar``.
+
+    Unlike a regular CookieJar, this class is pickleable.
+
+    .. warning:: dictionary operations that are normally O(1) may be O(n).
+    """
+
+    def get(self, name, default=None, domain=None, path=None):
+        """Dict-like get() that also supports optional domain and path args in
+        order to resolve naming collisions from using one cookie jar over
+        multiple domains.
+
+        .. warning:: operation is O(n), not O(1).
+        """
+        try:
+            value = self._find_no_duplicates(name, domain, path)
+            return value
+        except KeyError:
+            return default
+
+    def set(self, name, value, **kwargs):
+        """Dict-like set() that also supports optional domain and path args in
+        order to resolve naming collisions from using one cookie jar over
+        multiple domains.
+        """
+        # support client code that unsets cookies by assignment of a None value:
+        if value is None:
+            remove_cookie_by_name(self, name, domain=kwargs.get("domain"), path=kwargs.get("path"))
+            return None
+
+        if isinstance(value, Morsel):
+            c = morsel_to_cookie(value)
+        else:
+            c = create_cookie(name, value, **kwargs)
+        self.set_cookie(c)
+        return c
+
+    def iterkeys(self):
+        """Dict-like iterkeys() that returns an iterator of names of cookies
+        from the jar.
+
+        .. seealso:: itervalues() and iteritems().
+        """
+        for cookie in iter(self):
+            yield cookie.name
+
+    def keys(self):
+        """Dict-like keys() that returns a list of names of cookies from the
+        jar.
+
+        .. seealso:: values() and items().
+        """
+        return list(self.iterkeys())
+
+    def itervalues(self):
+        """Dict-like itervalues() that returns an iterator of values of cookies
+        from the jar.
+
+        .. seealso:: iterkeys() and iteritems().
+        """
+        for cookie in iter(self):
+            yield cookie.value
+
+    def values(self):
+        """Dict-like values() that returns a list of values of cookies from the
+        jar.
+
+        .. seealso:: keys() and items().
+        """
+        return list(self.itervalues())
+
+    def iteritems(self):
+        """Dict-like iteritems() that returns an iterator of name-value tuples
+        from the jar.
+
+        .. seealso:: iterkeys() and itervalues().
+        """
+        for cookie in iter(self):
+            yield cookie.name, cookie.value
+
+    def items(self):
+        """Dict-like items() that returns a list of name-value tuples from the
+        jar. Allows client-code to call ``dict(RequestsCookieJar)`` and get a
+        vanilla python dict of key value pairs.
+
+        .. seealso:: keys() and values().
+        """
+        return list(self.iteritems())
+
+    def list_domains(self):
+        """Utility method to list all the domains in the jar."""
+        domains = []
+        for cookie in iter(self):
+            if cookie.domain not in domains:
+                domains.append(cookie.domain)
+        return domains
+
+    def list_paths(self):
+        """Utility method to list all the paths in the jar."""
+        paths = []
+        for cookie in iter(self):
+            if cookie.path not in paths:
+                paths.append(cookie.path)
+        return paths
+
+    def multiple_domains(self):
+        """Returns True if there are multiple domains in the jar.
+        Returns False otherwise.
+
+        :rtype: bool
+        """
+        domains = []
+        for cookie in iter(self):
+            if cookie.domain is not None and cookie.domain in domains:
+                return True
+            domains.append(cookie.domain)
+        return False  # there is only one domain in jar
+
+    def get_dict(self, domain=None, path=None):
+        """Takes as an argument an optional domain and path and returns a plain
+        old Python dict of name-value pairs of cookies that meet the
+        requirements.
+
+        :rtype: dict
+        """
+        dictionary = {}
+        for cookie in iter(self):
+            if (domain is None or cookie.domain == domain) and (path is None or cookie.path == path):
+                dictionary[cookie.name] = cookie.value
+        return dictionary
+
+    def __contains__(self, name):
+        try:
+            return super().__contains__(name)
+        except CookieConflictError:
+            return True
+
+    def __getitem__(self, name):
+        """Dict-like __getitem__() for compatibility with client code. Throws
+        exception if there are more than one cookie with name. In that case,
+        use the more explicit get() method instead.
+
+        .. warning:: operation is O(n), not O(1).
+        """
+        return self._find_no_duplicates(name)
+
+    def __setitem__(self, name, value):
+        """Dict-like __setitem__ for compatibility with client code. Throws
+        exception if there is already a cookie of that name in the jar. In that
+        case, use the more explicit set() method instead.
+        """
+        self.set(name, value)
+
+    def __delitem__(self, name):
+        """Deletes a cookie given a name. Wraps ``http.cookiejar.CookieJar``'s
+        ``remove_cookie_by_name()``.
+        """
+        remove_cookie_by_name(self, name)
+
+    def set_cookie(self, cookie, *args, **kwargs):
+        if hasattr(cookie.value, "startswith") and cookie.value.startswith('"') and cookie.value.endswith('"'):
+            cookie.value = cookie.value.replace('\\"', "")
+        return super().set_cookie(cookie, *args, **kwargs)  # type: ignore
+
+    def update(self, other):  # noqa
+        """Updates this jar with cookies from another CookieJar or dict-like"""
+        if isinstance(other, cookielib.CookieJar):
+            for cookie in other:
+                self.set_cookie(copy.copy(cookie))
+        else:
+            super().update(other)
+
+    def _find(self, name, domain=None, path=None):
+        """Requests uses this method internally to get cookie values.
+
+        If there are conflicting cookies, _find arbitrarily chooses one.
+        See _find_no_duplicates if you want an exception thrown if there are
+        conflicting cookies.
+
+        :param name: a string containing name of cookie
+        :param domain: (optional) string containing domain of cookie
+        :param path: (optional) string containing path of cookie
+        :return: cookie.value
+        """
+        for cookie in iter(self):
+            if cookie.name == name:
+                if domain is None or cookie.domain == domain:
+                    if path is None or cookie.path == path:
+                        return cookie.value
+
+        raise KeyError(f"name={name!r}, domain={domain!r}, path={path!r}")
+
+    def _find_no_duplicates(self, name, domain=None, path=None):
+        """Both ``__get_item__`` and ``get`` call this function: it's never
+        used elsewhere in Requests.
+
+        :param name: a string containing name of cookie
+        :param domain: (optional) string containing domain of cookie
+        :param path: (optional) string containing path of cookie
+        :raises KeyError: if cookie is not found
+        :raises CookieConflictError: if there are multiple cookies
+            that match name and optionally domain and path
+        :return: cookie.value
+        """
+        toReturn = None
+        for cookie in iter(self):
+            if cookie.name == name:
+                if domain is None or cookie.domain == domain:
+                    if path is None or cookie.path == path:
+                        if toReturn is not None:
+                            # if there are multiple cookies that meet passed in criteria
+                            raise CookieConflictError(f"There are multiple cookies with name, {name!r}")
+                        # we will eventually return this as long as no cookie conflict
+                        toReturn = cookie.value
+
+        if toReturn is not None:
+            return toReturn
+        raise KeyError(f"name={name!r}, domain={domain!r}, path={path!r}")
+
+    def __getstate__(self):
+        """Unlike a normal CookieJar, this class is pickleable."""
+        state = self.__dict__.copy()
+        # remove the unpickleable RLock object
+        state.pop("_cookies_lock")
+        return state
+
+    def __setstate__(self, state):
+        """Unlike a normal CookieJar, this class is pickleable."""
+        self.__dict__.update(state)
+        if "_cookies_lock" not in self.__dict__:
+            import threading
+
+            self._cookies_lock = threading.RLock()
+
+    def copy(self):
+        """Return a copy of this RequestsCookieJar."""
+        new_cj = RequestsCookieJar()
+        new_cj.set_policy(self.get_policy())
+        new_cj.update(self)
+        return new_cj
+
+    def get_policy(self):
+        """Return the CookiePolicy instance used."""
+        return self._policy
+
+
+def extract_cookies_to_jar(cookiejar, response, request):
+    """Extract the cookies from the response into a CookieJar.
+
+    :param cookiejar: http.cookiejar.CookieJar (not necessarily a RequestsCookieJar)
+    :param request: our own requests.Request object
+    :param response: tls_requests.Response object
+    """
+    request = MockRequest(request)
+    response = MockResponse(response)
+    cookiejar.extract_cookies(response, request)
+
+
+def get_cookie_header(jar, request):
+    """
+    Produce an appropriate Cookie header string to be sent with `request`, or None.
+
+    :rtype: str
+    """
+    r = MockRequest(request)
+    jar.add_cookie_header(r)
+    return r.get_new_headers().get("Cookie")
+
+
+def remove_cookie_by_name(cookiejar, name, domain=None, path=None):
+    """Unsets a cookie by key, by default over all domains and paths.
+
+    Wraps CookieJar.clear(), is O(n).
+    """
+    clearables = []
+    for cookie in cookiejar:
+        if cookie.name != name:
+            continue
+        if domain is not None and domain != cookie.domain:
+            continue
+        if path is not None and path != cookie.path:
+            continue
+        clearables.append((cookie.domain, cookie.path, cookie.name))
+
+    for domain, path, name in clearables:
+        cookiejar.clear(domain, path, name)
+
+
+def _copy_cookie_jar(jar):
+    if jar is None:
+        return None
+
+    if hasattr(jar, "copy"):
+        # We're dealing with an instance of RequestsCookieJar
+        return jar.copy()
+    # We're dealing with a generic CookieJar instance
+    new_jar = copy.copy(jar)
+    new_jar.clear()
+    for cookie in jar:
+        new_jar.set_cookie(copy.copy(cookie))
+    return new_jar
+
+
+def create_cookie(name, value, **kwargs):
+    """Make a cookie from underspecified parameters.
+
+    By default, the pair of `key` and `value` will be set for the domain ''
+    and sent on every request (this is sometimes called a "supercookie").
+    """
+    result = {
+        "version": 0,
+        # "key": name, # remove unexpected arg
+        "name": name,  # fix unexpected arg
+        "value": value,
+        "port": None,
+        "domain": "",
+        "path": "/",
+        "secure": False,
+        "expires": None,
+        "discard": True,
+        "comment": None,
+        "comment_url": None,
+        "rest": {"HttpOnly": None},
+        "rfc2109": False,
+    }
+
+    badargs = set(kwargs) - set(result)
+    if badargs:
+        raise CookieError(f"create_cookie() got unexpected keyword arguments: {list(badargs)}")
+
+    result.update(kwargs)
+    result["port_specified"] = bool(result["port"])
+    result["domain_specified"] = bool(result["domain"])
+    result["domain_initial_dot"] = result["domain"].startswith(".")
+    result["path_specified"] = bool(result["path"])
+
+    return cookielib.Cookie(**result)
+
+
+def morsel_to_cookie(morsel):
+    """Convert a Morsel object into a Cookie containing the one k/v pair."""
+
+    expires = None
+    if morsel["max-age"]:
+        try:
+            expires = int(time.time() + int(morsel["max-age"]))
+        except ValueError:
+            raise CookieError(f"max-age: {morsel['max-age']} must be integer")
+    elif morsel["expires"]:
+        time_template = "%a, %d-%b-%Y %H:%M:%S GMT"
+        expires = calendar.timegm(time.strptime(morsel["expires"], time_template))
+    return create_cookie(
+        comment=morsel["comment"],
+        comment_url=bool(morsel["comment"]),
+        discard=False,
+        domain=morsel["domain"],
+        expires=expires,
+        name=morsel.key,
+        path=morsel["path"],
+        port=None,
+        rest={"HttpOnly": morsel["httponly"]},
+        rfc2109=False,
+        secure=bool(morsel["secure"]),
+        value=morsel.value,
+        version=morsel["version"] or 0,
+    )
+
+
+def cookiejar_from_dict(cookie_dict, cookiejar=None, overwrite=True):
+    """Returns a CookieJar from a key/value dictionary.
+
+    :param cookie_dict: Dict of key/values to insert into CookieJar.
+    :param cookiejar: (optional) A cookiejar to add the cookies to.
+    :param overwrite: (optional) If False, will not replace cookies
+        already in the jar with new ones.
+    :rtype: CookieJar
+    """
+    if cookiejar is None:
+        cookiejar = RequestsCookieJar()
+
+    if cookie_dict is not None:
+        names_from_jar = [cookie.name for cookie in cookiejar]
+        for name in cookie_dict:
+            if overwrite or (name not in names_from_jar):
+                cookiejar.set_cookie(create_cookie(name, cookie_dict[name]))
+
+    return cookiejar
+
+
+def merge_cookies(cookiejar, cookies):
+    """Add cookies to cookiejar and returns a merged CookieJar.
+
+    :param cookiejar: CookieJar object to add the cookies to.
+    :param cookies: Dictionary or CookieJar object to be added.
+    :rtype: CookieJar
+    """
+    if not isinstance(cookiejar, cookielib.CookieJar):
+        raise ValueError("You can only merge into CookieJar")
+
+    if isinstance(cookies, dict):
+        cookiejar = cookiejar_from_dict(cookies, cookiejar=cookiejar, overwrite=False)
+    elif isinstance(cookies, cookielib.CookieJar):
+        try:
+            cookiejar.update(cookies)
+        except AttributeError:
+            for cookie_in_jar in cookies:
+                cookiejar.set_cookie(cookie_in_jar)
+
+    return cookiejar
+
+
+class Cookies(MutableMapping[str, str]):
+    def __init__(self, cookies: CookieTypes = None) -> None:
+        self.cookiejar = self._prepare_cookiejar(cookies)
+
+    def _prepare_cookiejar(self, cookies: CookieTypes = None) -> RequestsCookieJar:
+        if isinstance(cookies, self.__class__):
+            return cookies.cookiejar
+
+        if isinstance(cookies, (dict, tuple, list, set)):
+            cookiejar = RequestsCookieJar()
+            if isinstance(cookies, dict):
+                cookies = cookies.items()
+
+            for k, v in cookies:
+                if isinstance(v, (float, int)):
+                    v = str(v)
+
+                cookiejar.set(k, v)
+            return cookiejar
+
+        return RequestsCookieJar()
+
+    def extract_cookies(self, response: Response, request: Request) -> None:
+        extract_cookies_to_jar(self.cookiejar, response, request)
+
+    def get_cookie_header(self, request: Request) -> str:
+        return get_cookie_header(self.cookiejar, request)
+
+    def set(self, name, value, **kwargs) -> Optional[Cookie]:
+        if value is None:
+            remove_cookie_by_name(self, name, domain=kwargs.get("domain"), path=kwargs.get("path"))
+            return None
+
+        if isinstance(value, Morsel):
+            cookie = morsel_to_cookie(value)
+        else:
+            cookie = create_cookie(name, value, **kwargs)
+
+        self.cookiejar.set_cookie(cookie)
+        return cookie
+
+    def get(self, name, default=None, domain=None, path=None) -> str:
+        return self.cookiejar.get(name, default, domain, path)
+
+    def delete(self, name: str, domain: str = None, path: str = None) -> None:
+        return remove_cookie_by_name(self.cookiejar, name)
+
+    def clear(self, domain: str = None, path: str = None):
+        args = []
+        if domain:
+            args.append(domain)
+        if domain and path:
+            args.append(path)
+
+        self.cookiejar.clear(*args)
+
+    def update(self, cookies: CookieTypes = None) -> "Cookies":  # noqa
+        self.cookiejar.update(self._prepare_cookiejar(cookies))
+        return self
+
+    def copy(self) -> "Cookies":
+        ret = self.__class__()
+        ret.cookiejar = _copy_cookie_jar(self.cookiejar)
+        return ret
+
+    def __setitem__(self, name: str, value: str) -> Optional[Cookie]:
+        return self.set(name, value)
+
+    def __getitem__(self, name: str) -> str:
+        return self.cookiejar.get(name)
+
+    def __delitem__(self, name: str) -> None:
+        return self.delete(name)
+
+    def __len__(self) -> int:
+        return len(self.cookiejar)
+
+    def __iter__(self) -> Iterator[str]:
+        return (cookie.name for cookie in self.cookiejar)
+
+    def __bool__(self) -> bool:
+        for _ in self.cookiejar:
+            return True
+        return False
+
+    def __repr__(self) -> str:
+        cookiejar_repr = ", ".join([repr(cookie) for cookie in self.cookiejar])
+        return "<%s[%s]>" % (self.__class__.__name__, cookiejar_repr)

--- a/vendor/tls_requests/models/encoders.py
+++ b/vendor/tls_requests/models/encoders.py
@@ -1,0 +1,304 @@
+import binascii
+import os
+from io import BufferedReader, BytesIO, TextIOWrapper
+from mimetypes import guess_type
+from typing import Any, AsyncIterator, Dict, Iterator, Mapping, Tuple, TypeVar
+from urllib.parse import urlencode
+
+from ..types import (BufferTypes, ByteOrStr, RequestData, RequestFiles,
+                     RequestFileValue, RequestJson)
+from ..utils import to_bytes, to_str
+
+__all__ = [
+    "JsonEncoder",
+    "UrlencodedEncoder",
+    "MultipartEncoder",
+    "StreamEncoder",
+]
+
+T = TypeVar("T", bound="BaseEncoder")
+
+
+def guess_content_type(fp: str) -> str:
+    content_type, _ = guess_type(fp)
+    return content_type or "application/octet-stream"
+
+
+def format_header(name: str, value: ByteOrStr, encoding: str = "ascii") -> bytes:
+    if isinstance(value, bytes):
+        value = value.decode("utf-8")
+
+    value = value.translate({10: "%0A", 13: "%0D", 34: "%22"})
+    return ('%s="%s"' % (name, value)).encode(encoding)
+
+
+def get_boundary():
+    return binascii.hexlify(os.urandom(16))
+
+
+def iter_buffer(buffer: BufferTypes, chunk_size: int = 65_536):
+    buffer.seek(0)
+    while chunk := buffer.read(chunk_size):
+        yield chunk
+
+
+class BaseField:
+    def __init__(self, name: str, value: Any):
+        self._name = name
+        self._headers = {}
+
+    @property
+    def headers(self):
+        return self.render_headers()
+
+    def render_parts(self) -> bytes:
+        parts = [
+            b"form-data",
+            format_header("name", self._name),
+        ]
+        filename = getattr(self, "filename", None)
+        if filename:
+            parts.append(format_header("filename", filename))
+
+        return b"; ".join(parts)
+
+    def render_headers(self) -> bytes:
+        headers = self.get_headers()
+        return b"\r\n".join(b"%s: %s" % (k, v) for k, v in headers.items()) + b"\r\n\r\n"
+
+    def render_data(self, chunk_size: int = 65_536) -> Iterator[bytes]:
+        yield b""
+
+    def render(self, chunk_size: int = 65_536) -> Iterator[bytes]:
+        yield self.render_headers()
+        yield from self.render_data(chunk_size)
+
+    def get_headers(self) -> Dict[bytes, bytes]:
+        self._headers[b"Content-Disposition"] = self.render_parts()
+        content_type = getattr(self, "content_type", None)
+        if content_type:
+            self._headers[b"Content-Type"] = (
+                self.content_type.encode("ascii") if isinstance(content_type, str) else content_type
+            )
+        return self._headers
+
+
+class DataField(BaseField):
+    def __init__(self, name: str, value: Any) -> None:
+        super(DataField, self).__init__(name, value)
+        self.value = to_str(value)
+
+    def render_data(self, chunk_size: int = 65_536) -> Iterator[bytes]:
+        yield self.value.encode("utf-8")
+
+
+class FileField(BaseField):
+    def __init__(self, name: str, value: RequestFileValue):
+        super(FileField, self).__init__(name, value)
+        self.filename, self._buffer, self.content_type = self.unpack(value)
+
+    def unpack(self, value: RequestFileValue) -> Tuple[str, BufferTypes, str]:
+        filename, content_type = None, None
+        if isinstance(value, tuple):
+            if len(value) > 1:
+                filename, buffer, *args = value
+                if args:
+                    content_type = args[0]
+            else:
+                buffer = value
+
+        elif isinstance(value, str):
+            buffer = value.encode("utf-8")
+        else:
+            buffer = value
+
+        if isinstance(buffer, (TextIOWrapper, BufferedReader)):
+            if not filename:
+                _, filename = os.path.split(buffer.name)
+
+            if not content_type:
+                content_type = guess_content_type(buffer.name)
+
+            if buffer.mode != "rb":
+                buffer.close()
+                buffer = open(buffer.name, "rb")
+
+        elif not isinstance(buffer, bytes):
+            raise ValueError
+        else:
+            buffer = BytesIO(buffer)
+
+        return filename or "upload", buffer, content_type or "application/octet-stream"
+
+    def render_data(self, chunk_size: int = 65_536) -> Iterator[bytes]:
+        yield from iter_buffer(self._buffer, chunk_size)
+
+
+class BaseEncoder:
+    _chunk_size = 65_536
+
+    @property
+    def headers(self) -> dict:
+        return self.get_headers()
+
+    @property
+    def closed(self):
+        return bool(getattr(self, "_is_closed", False))
+
+    def get_headers(self) -> dict:
+        return {}
+
+    def render(self) -> Iterator[bytes]:
+        buffer = getattr(self, "_buffer", None)
+        if buffer:
+            yield from iter_buffer(buffer, self._chunk_size)
+        yield b""
+
+    def close(self) -> None:
+        if not self.closed:
+            setattr(self, "_is_closed", True)
+            buffer = getattr(self, "_buffer", None)
+            if buffer:
+                buffer.flush()
+                buffer.close()
+
+    def __iter__(self) -> Iterator[bytes]:
+        for chunk in self.render():
+            yield chunk
+
+    async def __aiter__(self) -> AsyncIterator[bytes]:
+        for chunk in self.render():
+            yield chunk
+
+    def __enter__(self) -> T:
+        return self
+
+    def __exit__(self, *args, **kwargs):
+        self.close()
+
+
+class MultipartEncoder(BaseEncoder):
+    def __init__(
+        self,
+        data: RequestData = None,
+        files: RequestFiles = None,
+        boundary: bytes = None,
+        *,
+        chunk_size: int = 65_536,
+        **kwargs,
+    ) -> None:
+        self._chunk_size = chunk_size
+        self._is_closed = False
+        self.fields = self._prepare_fields(data, files)
+        self.boundary = boundary if boundary and isinstance(boundary, bytes) else get_boundary()
+
+    @property
+    def headers(self) -> dict:
+        if self.fields:
+            return self.get_headers()
+        return {}
+
+    def get_headers(self):
+        return {b"Content-Type": b"multipart/form-data; boundary=%s" % self.boundary}
+
+    def render(self) -> Iterator[bytes]:
+        if self.fields:
+            for field in self.fields:
+                yield b"--%s\r\n" % self.boundary
+                yield b"".join(field.render(self._chunk_size))
+                yield b"\r\n"
+            yield b"--%s--\r\n" % self.boundary
+        yield b""
+
+    def _prepare_fields(self, data: RequestData, files: RequestFiles):
+        fields = []
+        if isinstance(data, Mapping):
+            for name, value in data.items():
+                if isinstance(value, (bytes, str, int, float, bool)):
+                    fields.append(DataField(name=name, value=value))
+                else:
+                    for item in value:
+                        fields.append(DataField(name=name, value=item))
+
+        if isinstance(files, Mapping):
+            for name, value in files.items():
+                fields.append(FileField(name=name, value=value))
+        return fields
+
+
+class JsonEncoder(BaseEncoder):
+    def __init__(self, data: RequestData, *, chunk_size: int = 65_536, **kwargs):
+        self._buffer = self._prepare_fields(data)
+        self._chunk_size = chunk_size
+        self._is_closed = False
+
+    def get_headers(self):
+        return {b"Content-Type": b"application/json"}
+
+    def _prepare_fields(self, data: RequestData):
+        if isinstance(data, Mapping):
+            return BytesIO(to_bytes(data))
+
+
+class UrlencodedEncoder(BaseEncoder):
+    def __init__(self, data: RequestData, *, chunk_size: int = 65_536, **kwargs):
+        self._buffer = self._prepare_fields(data)
+        self._chunk_size = chunk_size
+        self._is_closed = False
+
+    def get_headers(self):
+        return {b"Content-Type": b"application/x-www-form-urlencoded"}
+
+    def _prepare_fields(self, data: RequestData):
+        fields = []
+        if isinstance(data, Mapping):
+            for name, value in data.items():
+                if isinstance(value, (bytes, str, int, float, bool)):
+                    fields.append((name, to_str(value)))
+                else:
+                    for item in value:
+                        fields.append((name, to_str(item)))
+
+            return BytesIO(urlencode(fields, doseq=True).encode("utf-8"))
+
+
+class StreamEncoder(BaseEncoder):
+    def __init__(
+        self,
+        data: RequestData = None,
+        files: RequestFiles = None,
+        json: RequestJson = None,
+        *,
+        chunk_size: int = 65_536,
+        **kwargs,
+    ):
+        self._chunk_size = chunk_size if isinstance(chunk_size, int) else 65_536
+        self._is_closed = False
+        if files is not None:
+            self._stream = MultipartEncoder(data, files)
+        elif data is not None:
+            self._stream = UrlencodedEncoder(data)
+        elif json is not None:
+            self._stream = JsonEncoder(json)
+        else:
+            self._stream = BaseEncoder()
+
+    def render(self) -> Iterator[bytes]:
+        yield from self._stream
+        self._is_closed = True
+
+    def get_headers(self) -> dict:
+        return self._stream.get_headers()
+
+    @classmethod
+    def from_bytes(cls, raw: bytes, *, chunk_size: int = None) -> "StreamEncoder":
+        ret = cls(chunk_size=chunk_size)
+        ret._stream._buffer = BytesIO(raw)
+        return ret
+
+    def close(self):
+        super().close()
+        self._stream.close()
+
+    def __exit__(self, *args, **kwargs):
+        self.close()

--- a/vendor/tls_requests/models/headers.py
+++ b/vendor/tls_requests/models/headers.py
@@ -1,0 +1,150 @@
+from collections.abc import Mapping, MutableMapping
+from enum import Enum
+from typing import Any, ItemsView, KeysView, List, Literal, Tuple, ValuesView
+
+from ..exceptions import HeaderError
+from ..types import ByteOrStr, HeaderTypes
+from ..utils import to_str
+
+__all__ = ["Headers"]
+
+HeaderAliasTypes = Literal["*", "lower", "capitalize"]
+
+
+class HeaderAlias(str, Enum):
+    LOWER = "lower"
+    CAPITALIZE = "capitalize"
+    ALL = "*"
+
+    def __contains__(self, key: str) -> bool:
+        for item in self:
+            if item == key:
+                return True
+        return False
+
+
+class Headers(MutableMapping):
+    def __init__(self, headers: HeaderTypes = None, *, alias: HeaderAliasTypes = HeaderAlias.LOWER):
+        self.alias = alias if alias in HeaderAlias._value2member_map_ else HeaderAlias.LOWER
+        self._items = self._prepare_items(headers)
+
+    def get(self, key: str, default: Any = None) -> Any:
+        key = self._normalize_key(key)
+        for k, v in self._items:
+            if k == key:
+                return ",".join(v)
+        return default
+
+    def items(self) -> ItemsView:
+        return {k: ",".join(v) for k, v in self._items}.items()
+
+    def keys(self) -> KeysView:
+        return {k: v for k, v in self.items()}.keys()
+
+    def values(self) -> ValuesView:
+        return {k: v for k, v in self.items()}.values()
+
+    def update(self, headers: HeaderTypes) -> "Headers":  # noqa
+        headers = self.__class__(headers, alias=self.alias)  # noqa
+        for idx, (key, _) in enumerate(headers._items):
+            if key in self:
+                self.pop(key)
+
+        self._items.extend(headers._items)
+        return self
+
+    def copy(self) -> "Headers":
+        return self.__class__(self._items.copy(), alias=self.alias)  # noqa
+
+    def _prepare_items(self, headers: HeaderTypes) -> List[Tuple[str, Any]]:
+        if headers is None:
+            return []
+        if isinstance(headers, self.__class__):
+            return [self._normalize(k, v) for k, v in headers._items]
+        if isinstance(headers, Mapping):
+            return [self._normalize(k, v) for k, v in headers.items()]
+        if isinstance(headers, (list, tuple, set)):
+            try:
+                items = [self._normalize(k, args[0]) for k, *args in headers]
+                return items
+            except IndexError:
+                pass
+        raise HeaderError
+
+    def _normalize_key(self, key: ByteOrStr) -> str:
+        key = to_str(key, encoding="ascii")
+        if self.alias == HeaderAlias.ALL:
+            return key
+
+        if self.alias == HeaderAlias.CAPITALIZE:
+            return "-".join([s.capitalize() for s in key.split("-")])
+
+        return key.lower()
+
+    def _normalize_value(self, value) -> List[str]:
+        if isinstance(value, dict):
+            raise HeaderError
+
+        if isinstance(value, (list, tuple, set)):
+            items = []
+            for item in value:
+                if isinstance(item, dict):
+                    raise HeaderError
+                items.append(to_str(item))
+            return items
+
+        return [to_str(value)]
+
+    def _normalize(self, key, value) -> Tuple[str, List[str]]:
+        return self._normalize_key(key), self._normalize_value(value)
+
+    def __setitem__(self, key, value) -> None:
+        found = False
+        key, value = self._normalize(key, value)
+        for idx, (k, _) in enumerate(self._items):
+            if k == key:
+                self._items[idx] = (k, value)
+                found = True
+                break
+
+        if not found:
+            self._items.append((key, value))
+
+    def __getitem__(self, key):
+        return self.get(key)
+
+    def __delitem__(self, key):
+        key = self._normalize_key(key)
+        pop_idx = None
+        for idx, (k, _) in enumerate(self._items):
+            if key == k:
+                pop_idx = idx
+                break
+
+        if pop_idx is not None:
+            self._items.pop(pop_idx)
+
+    def __contains__(self, key: Any) -> bool:
+        key = self._normalize_key(key)
+        for k, _ in self._items:
+            if key == k:
+                return True
+        return False
+
+    def __iter__(self):
+        return (k for k, _ in self._items)
+
+    def __len__(self):
+        return len(self._headers)
+
+    def __eq__(self, other: HeaderTypes):
+        items = sorted(self._items)
+        other = sorted(self._prepare_items(other))
+        return items == other
+
+    def __repr__(self):
+        SECURE = [self._normalize_key(key) for key in ["Authorization", "Proxy-Authorization"]]
+        return "<%s: %s>" % (
+            self.__class__.__name__,
+            {k: "[secure]" if k in SECURE else ",".join(v) for k, v in self._items},
+        )

--- a/vendor/tls_requests/models/libraries.py
+++ b/vendor/tls_requests/models/libraries.py
@@ -1,0 +1,464 @@
+import ctypes
+import glob
+import json
+import os
+import platform
+import re
+import sys
+import urllib.error
+import urllib.request
+from dataclasses import dataclass, field, fields
+from pathlib import Path
+from platform import machine
+from typing import List, Optional, Tuple
+
+from tls_requests.utils import get_logger
+
+logger = get_logger("TLSLibrary")
+
+__all__ = ["TLSLibrary"]
+
+LATEST_VERSION_TAG_NAME = "v1.11.2"
+BIN_DIR = os.path.join(Path(__file__).resolve(strict=True).parent.parent / "bin")
+GITHUB_API_URL = "https://api.github.com/repos/bogdanfinn/tls-client/releases"
+PLATFORM = sys.platform
+IS_UBUNTU = False
+ARCH_MAPPING = {
+    "amd64": "amd64",
+    "x86_64": "amd64",
+    "x86": "386",
+    "i686": "386",
+    "i386": "386",
+    "arm64": "arm64",
+    "aarch64": "arm64",
+    "armv5l": "arm-5",
+    "armv6l": "arm-6",
+    "armv7l": "arm-7",
+    "ppc64le": "ppc64le",
+    "riscv64": "riscv64",
+    "s390x": "s390x",
+}
+
+FILE_EXT = ".unk"
+MACHINE = ARCH_MAPPING.get(machine()) or machine()
+if PLATFORM == "linux":
+    FILE_EXT = "so"
+    try:
+        platform_data = platform.freedesktop_os_release()
+        if "ID" in platform_data:
+            curr_system = platform_data["ID"]
+        else:
+            curr_system = platform_data.get("id")
+
+        if "ubuntu" in str(curr_system).lower():
+            IS_UBUNTU = True
+
+    except Exception as e:  # noqa
+        pass
+
+elif PLATFORM in ("win32", "cygwin"):
+    PLATFORM = "windows"
+    FILE_EXT = "dll"
+elif PLATFORM == "darwin":
+    FILE_EXT = "dylib"
+
+PATTERN_RE = re.compile(r"%s-%s.*%s" % (PLATFORM, MACHINE, FILE_EXT), re.I)
+PATTERN_UBUNTU_RE = re.compile(r"%s-%s.*%s" % ("ubuntu", MACHINE, FILE_EXT), re.I)
+TLS_LIBRARY_PATH = os.getenv("TLS_LIBRARY_PATH")
+
+
+@dataclass
+class BaseRelease:
+
+    @classmethod
+    def model_fields_set(cls) -> set:
+        return {model_field.name for model_field in fields(cls)}
+
+    @classmethod
+    def from_kwargs(cls, **kwargs):
+        model_fields_set = cls.model_fields_set()
+        return cls(**{k: v for k, v in kwargs.items() if k in model_fields_set})  # noqa
+
+
+@dataclass
+class ReleaseAsset(BaseRelease):
+    browser_download_url: str
+    name: Optional[str] = None
+
+
+@dataclass
+class Release(BaseRelease):
+    name: Optional[str] = None
+    tag_name: Optional[str] = None
+    assets: List[ReleaseAsset] = field(default_factory=list)
+
+    @classmethod
+    def from_kwargs(cls, **kwargs):
+        model_fields_set = cls.model_fields_set()
+        assets = kwargs.pop("assets", []) or []
+        kwargs["assets"] = [ReleaseAsset.from_kwargs(**asset_kwargs) for asset_kwargs in assets]
+        return cls(**{k: v for k, v in kwargs.items() if k in model_fields_set})
+
+
+class TLSLibrary:
+    """TLS Library
+
+    A utility class for managing the TLS library, including discovery, validation,
+    downloading, and loading. This class facilitates interaction with system-specific
+    binaries, ensuring compatibility with the platform and machine architecture.
+
+    Class Attributes:
+        _PATH (str): The current path to the loaded TLS library.
+
+    Methods:
+        fetch_api(version: Optional[str] = None, retries: int = 3) -> Generator[str, None, None]:
+            Fetches library download URLs from the GitHub API for the specified version.
+
+        is_valid(fp: str) -> bool:
+            Validates a file path against platform-specific patterns.
+
+        find() -> str:
+            Finds the first valid library binary in the binary directory.
+
+        find_all() -> list[str]:
+            Lists all library binaries in the binary directory.
+
+        download(version: Optional[str] = None) -> str:
+            Downloads the library binary for the specified version.
+
+        set_path(fp: str):
+            Sets the path to the currently loaded library.
+
+        load() -> ctypes.CDLL:
+            Loads the library, either from an existing path or by discovering and downloading it.
+    """
+
+    _PATH: str = None
+    _LIBRARY: Optional[ctypes.CDLL] = None
+    _STATIC_API_DATA = {
+        "name": "v1.11.2",
+        "tag_name": "v1.11.2",
+        "assets": [
+            {
+                "browser_download_url": "https://github.com/bogdanfinn/tls-client/releases/download/v1.11.2/tls-client-darwin-amd64-1.11.2.dylib",
+                "name": "tls-client-darwin-amd64-1.11.2.dylib",
+            },
+            {
+                "browser_download_url": "https://github.com/bogdanfinn/tls-client/releases/download/v1.11.2/tls-client-darwin-arm64-1.11.2.dylib",
+                "name": "tls-client-darwin-arm64-1.11.2.dylib",
+            },
+            {
+                "browser_download_url": "https://github.com/bogdanfinn/tls-client/releases/download/v1.11.2/tls-client-linux-alpine-amd64-1.11.2.so",
+                "name": "tls-client-linux-alpine-amd64-1.11.2.so",
+            },
+            {
+                "browser_download_url": "https://github.com/bogdanfinn/tls-client/releases/download/v1.11.2/tls-client-linux-arm64-1.11.2.so",
+                "name": "tls-client-linux-arm64-1.11.2.so",
+            },
+            {
+                "browser_download_url": "https://github.com/bogdanfinn/tls-client/releases/download/v1.11.2/tls-client-linux-armv7-1.11.2.so",
+                "name": "tls-client-linux-armv7-1.11.2.so",
+            },
+            {
+                "browser_download_url": "https://github.com/bogdanfinn/tls-client/releases/download/v1.11.2/tls-client-linux-ubuntu-amd64-1.11.2.so",
+                "name": "tls-client-linux-ubuntu-amd64-1.11.2.so",
+            },
+            {
+                "browser_download_url": "https://github.com/bogdanfinn/tls-client/releases/download/v1.11.2/tls-client-windows-32-1.11.2.dll",
+                "name": "tls-client-windows-32-1.11.2.dll",
+            },
+            {
+                "browser_download_url": "https://github.com/bogdanfinn/tls-client/releases/download/v1.11.2/tls-client-windows-64-1.11.2.dll",
+                "name": "tls-client-windows-64-1.11.2.dll",
+            },
+            {
+                "browser_download_url": "https://github.com/bogdanfinn/tls-client/releases/download/v1.11.2/tls-client-xgo-1.11.2-darwin-amd64.dylib",
+                "name": "tls-client-xgo-1.11.2-darwin-amd64.dylib",
+            },
+            {
+                "browser_download_url": "https://github.com/bogdanfinn/tls-client/releases/download/v1.11.2/tls-client-xgo-1.11.2-darwin-arm64.dylib",
+                "name": "tls-client-xgo-1.11.2-darwin-arm64.dylib",
+            },
+            {
+                "browser_download_url": "https://github.com/bogdanfinn/tls-client/releases/download/v1.11.2/tls-client-xgo-1.11.2-linux-386.so",
+                "name": "tls-client-xgo-1.11.2-linux-386.so",
+            },
+            {
+                "browser_download_url": "https://github.com/bogdanfinn/tls-client/releases/download/v1.11.2/tls-client-xgo-1.11.2-linux-amd64.so",
+                "name": "tls-client-xgo-1.11.2-linux-amd64.so",
+            },
+            {
+                "browser_download_url": "https://github.com/bogdanfinn/tls-client/releases/download/v1.11.2/tls-client-xgo-1.11.2-linux-arm-5.so",
+                "name": "tls-client-xgo-1.11.2-linux-arm-5.so",
+            },
+            {
+                "browser_download_url": "https://github.com/bogdanfinn/tls-client/releases/download/v1.11.2/tls-client-xgo-1.11.2-linux-arm-6.so",
+                "name": "tls-client-xgo-1.11.2-linux-arm-6.so",
+            },
+            {
+                "browser_download_url": "https://github.com/bogdanfinn/tls-client/releases/download/v1.11.2/tls-client-xgo-1.11.2-linux-arm-7.so",
+                "name": "tls-client-xgo-1.11.2-linux-arm-7.so",
+            },
+            {
+                "browser_download_url": "https://github.com/bogdanfinn/tls-client/releases/download/v1.11.2/tls-client-xgo-1.11.2-linux-arm64.so",
+                "name": "tls-client-xgo-1.11.2-linux-arm64.so",
+            },
+            {
+                "browser_download_url": "https://github.com/bogdanfinn/tls-client/releases/download/v1.11.2/tls-client-xgo-1.11.2-linux-ppc64le.so",
+                "name": "tls-client-xgo-1.11.2-linux-ppc64le.so",
+            },
+            {
+                "browser_download_url": "https://github.com/bogdanfinn/tls-client/releases/download/v1.11.2/tls-client-xgo-1.11.2-linux-riscv64.so",
+                "name": "tls-client-xgo-1.11.2-linux-riscv64.so",
+            },
+            {
+                "browser_download_url": "https://github.com/bogdanfinn/tls-client/releases/download/v1.11.2/tls-client-xgo-1.11.2-linux-s390x.so",
+                "name": "tls-client-xgo-1.11.2-linux-s390x.so",
+            },
+            {
+                "browser_download_url": "https://github.com/bogdanfinn/tls-client/releases/download/v1.11.2/tls-client-xgo-1.11.2-windows-386.dll",
+                "name": "tls-client-xgo-1.11.2-windows-386.dll",
+            },
+            {
+                "browser_download_url": "https://github.com/bogdanfinn/tls-client/releases/download/v1.11.2/tls-client-xgo-1.11.2-windows-amd64.dll",
+                "name": "tls-client-xgo-1.11.2-windows-amd64.dll",
+            },
+        ],
+    }
+
+    @staticmethod
+    def _parse_version(version_string: str) -> Tuple[int, ...]:
+        """Converts a version string (e.g., "v1.11.2") to a comparable tuple (1, 11, 2)."""
+        try:
+            parts = version_string.lstrip("v").split(".")
+            return tuple(map(int, parts))
+        except (ValueError, AttributeError):
+            return 0, 0, 0
+
+    @staticmethod
+    def _parse_version_from_filename(filename: str) -> Tuple[int, ...]:
+        """Extracts and parses the version from a library filename."""
+        match = re.search(r"v?(\d+\.\d+\.\d+)", Path(filename).name)
+        if match:
+            return TLSLibrary._parse_version(match.group(1))
+        return 0, 0, 0
+
+    @classmethod
+    def cleanup_files(cls, keep_file: str = None):
+        """Removes all library files in the BIN_DIR except for the one to keep."""
+        for file_path in cls.find_all():
+            is_remove = True
+            if keep_file and Path(file_path).name == Path(keep_file).name:
+                is_remove = False
+
+            if is_remove:
+                try:
+                    os.remove(file_path)
+                    logger.info(f"Removed old library file: {file_path}")
+                except OSError as e:
+                    logger.error(f"Error removing old library file {file_path}: {e}")
+
+    @classmethod
+    def fetch_api(cls, version: str = None, retries: int = 3):
+        def _find_release(data, version_: str = None):
+            releases = [Release.from_kwargs(**kwargs) for kwargs in data]
+
+            if version_ is not None:
+                version_ = "v%s" % version_ if not str(version_).startswith("v") else str(version_)
+                releases = [release for release in releases if re.search(version_, release.name, re.I)]
+
+            for release in releases:
+                for asset in release.assets:
+                    if IS_UBUNTU and PATTERN_UBUNTU_RE.search(asset.browser_download_url):
+                        ubuntu_urls.append(asset.browser_download_url)
+                    if PATTERN_RE.search(asset.browser_download_url):
+                        asset_urls.append(asset.browser_download_url)
+
+        asset_urls, ubuntu_urls = [], []
+        for _ in range(retries):
+            try:
+                # Use standard library's urllib to fetch API data
+                with urllib.request.urlopen(GITHUB_API_URL, timeout=10) as response:
+                    if response.status == 200:
+                        content = response.read().decode("utf-8")
+                        _find_release(json.loads(content))
+                        break
+            except Exception as ex:
+                logger.error("Unable to fetch GitHub API: %s" % ex)
+
+        if not asset_urls and not ubuntu_urls:
+            _find_release([cls._STATIC_API_DATA])
+
+        for url in ubuntu_urls:
+            yield url
+
+        for url in asset_urls:
+            yield url
+
+    @classmethod
+    def find(cls) -> str:
+        for fp in cls.find_all():
+            if PATTERN_RE.search(fp):
+                return fp
+        return None
+
+    @classmethod
+    def find_all(cls) -> List[str]:
+        return [src for src in glob.glob(os.path.join(BIN_DIR, r"*")) if src.lower().endswith(("so", "dll", "dylib"))]
+
+    @classmethod
+    def update(cls):
+        """Forces a download of the latest library version."""
+        logger.info(f"Updating TLS library to version {LATEST_VERSION_TAG_NAME}...")
+        downloaded_fp = cls.download(version=LATEST_VERSION_TAG_NAME)
+        if downloaded_fp:
+            cls.cleanup_files(keep_file=downloaded_fp)
+            logger.info("Update complete.")
+            return downloaded_fp
+        logger.error("Update failed.")
+
+    upgrade = update
+
+    @classmethod
+    def download(cls, version: str = None) -> str:
+        try:
+            logger.info(
+                "System Info - Platform: %s, Machine: %s, File Ext : %s."
+                % (
+                    PLATFORM,
+                    "%s (Ubuntu)" % MACHINE if IS_UBUNTU else MACHINE,
+                    FILE_EXT,
+                )
+            )
+            download_url = None
+            for url in cls.fetch_api(version):
+                if url:
+                    download_url = url
+                    break
+
+            logger.info("Library Download URL: %s" % download_url)
+            if download_url:
+                destination_name = download_url.split("/")[-1]
+                destination = os.path.join(BIN_DIR, destination_name)
+
+                # Use standard library's urllib to download the file
+                with urllib.request.urlopen(download_url, timeout=10) as response:
+                    if response.status != 200:
+                        raise urllib.error.URLError(f"Failed to download file: HTTP {response.status}")
+
+                    os.makedirs(BIN_DIR, exist_ok=True)
+                    total_size = int(response.headers.get("content-length", 0))
+                    chunk_size = 8192  # 8KB
+
+                    with open(destination, "wb") as file:
+                        downloaded = 0
+                        while True:
+                            chunk = response.read(chunk_size)
+                            if not chunk:
+                                break
+
+                            file.write(chunk)
+                            downloaded += len(chunk)
+
+                            # Simple text-based progress bar
+                            if total_size > 0:
+                                percent = downloaded / total_size * 100
+                                bar_length = 50
+                                filled_length = int(bar_length * downloaded // total_size)
+                                bar = "=" * filled_length + "-" * (bar_length - filled_length)
+                                sys.stdout.write(f"\rDownloading {destination_name}: [{bar}] {percent:.1f}%")
+                                sys.stdout.flush()
+
+                return destination
+
+        except (urllib.error.URLError, urllib.error.HTTPError) as ex:
+            logger.error("Unable to download file: %s" % ex)
+        except Exception as e:
+            logger.error("An unexpected error occurred during download: %s" % e)
+
+    @classmethod
+    def set_path(cls, fp: str):
+        cls._PATH = fp
+
+    @classmethod
+    def load(cls):
+        """
+        Loads the TLS library. It checks for the correct version, downloads it if
+        the local version is outdated or missing, and then loads it into memory.
+        """
+        target_version = cls._parse_version(LATEST_VERSION_TAG_NAME)
+
+        if cls._LIBRARY and cls._PATH:
+            cached_version = cls._parse_version_from_filename(cls._PATH)
+            if cached_version == target_version:
+                return cls._LIBRARY
+
+        def _load_library(fp_):
+            try:
+                lib = ctypes.cdll.LoadLibrary(fp_)
+                cls.set_path(fp_)
+                cls._LIBRARY = lib
+                logger.info(f"Successfully loaded TLS library: {fp_}")
+                return lib
+            except Exception as ex:
+                logger.error(f"Unable to load TLS library '{fp_}', details: {ex}")
+                try:
+                    os.remove(fp_)
+                except (FileNotFoundError, PermissionError):
+                    pass
+
+        if TLS_LIBRARY_PATH:
+            logger.info(f"Loading TLS library from environment variable: {TLS_LIBRARY_PATH}")
+            return _load_library(TLS_LIBRARY_PATH)
+
+        logger.debug(f"Required library version: {LATEST_VERSION_TAG_NAME}")
+        local_files = cls.find_all()
+        newest_local_version = (0, 0, 0)
+        newest_local_file = None
+
+        if local_files:
+            for file_path in local_files:
+                file_version = cls._parse_version_from_filename(file_path)
+                if file_version > newest_local_version:
+                    newest_local_version = file_version
+                    newest_local_file = file_path
+            logger.debug(
+                f"Found newest local library: {newest_local_file} (version {'.'.join(map(str, newest_local_version))})"
+            )
+        else:
+            logger.debug("No local library found.")
+
+        if newest_local_version < target_version:
+            if newest_local_file:
+                logger.warning(
+                    f"Local library is outdated (Found: {'.'.join(map(str, newest_local_version))}, "
+                    f"Required: {LATEST_VERSION_TAG_NAME}). "
+                    f"Auto-downloading... To manually upgrade, run: `python -m tls_requests.models.libraries`"
+                )
+            else:
+                logger.info(f"Downloading required library version {LATEST_VERSION_TAG_NAME}...")
+
+            downloaded_fp = cls.download(version=LATEST_VERSION_TAG_NAME)
+            if downloaded_fp:
+                cls.cleanup_files(keep_file=downloaded_fp)
+                library = _load_library(downloaded_fp)
+                if library:
+                    return library
+
+            logger.error(
+                f"Failed to download the required TLS library {LATEST_VERSION_TAG_NAME}. "
+                "Please check your connection or download it manually from GitHub."
+            )
+            raise OSError("Failed to download the required TLS library.")
+
+        if newest_local_file:
+            library = _load_library(newest_local_file)
+            if library:
+                cls.cleanup_files(keep_file=newest_local_file)
+                return library
+
+        raise OSError("Could not find or load a compatible TLS library.")
+
+
+if __name__ == "__main__":
+    TLSLibrary.update()

--- a/vendor/tls_requests/models/request.py
+++ b/vendor/tls_requests/models/request.py
@@ -1,0 +1,63 @@
+from typing import Any
+
+from ..settings import DEFAULT_TIMEOUT
+from ..types import (CookieTypes, HeaderTypes, MethodTypes, ProxyTypes,
+                     RequestData, RequestFiles, TimeoutTypes, URLParamTypes,
+                     URLTypes)
+from .cookies import Cookies
+from .encoders import StreamEncoder
+from .headers import Headers
+from .urls import URL, Proxy
+
+__all__ = ["Request"]
+
+
+class Request:
+    def __init__(
+        self,
+        method: MethodTypes,
+        url: URLTypes,
+        *,
+        data: RequestData = None,
+        files: RequestFiles = None,
+        json: Any = None,
+        params: URLParamTypes = None,
+        headers: HeaderTypes = None,
+        cookies: CookieTypes = None,
+        proxy: ProxyTypes = None,
+        timeout: TimeoutTypes = None,
+    ) -> None:
+        self._content = None
+        self._session_id = None
+        self.url = URL(url, params=params)
+        self.method = method.upper()
+        self.cookies = Cookies(cookies)
+        self.proxy = Proxy(proxy) if proxy else None
+        self.timeout = timeout if isinstance(timeout, (float, int)) else DEFAULT_TIMEOUT
+        self.stream = StreamEncoder(data, files, json)
+        self.headers = self._prepare_headers(headers)
+
+    def _prepare_headers(self, headers) -> Headers:
+        headers = Headers(headers)
+        headers.update(self.stream.headers)
+        if self.url.host and "Host" not in headers:
+            headers.setdefault(b"Host", self.url.host)
+
+        return headers
+
+    @property
+    def id(self):
+        return self._session_id
+
+    @property
+    def content(self) -> bytes:
+        return self._content
+
+    def read(self):
+        return b"".join(self.stream.render())
+
+    async def aread(self):
+        return b"".join(await self.stream.render())
+
+    def __repr__(self) -> str:
+        return "<%s: (%s, %s)>" % (self.__class__.__name__, self.method, self.url)

--- a/vendor/tls_requests/models/response.py
+++ b/vendor/tls_requests/models/response.py
@@ -1,0 +1,259 @@
+import binascii
+import codecs
+import datetime
+from email.message import Message
+from typing import Any, Callable, Optional, TypeVar, Union
+
+from ..exceptions import Base64DecodeError, HTTPError
+from ..settings import CHUNK_SIZE
+from ..types import CookieTypes, HeaderTypes, ResponseHistory
+from ..utils import b64decode, chardet, to_json
+from .cookies import Cookies
+from .encoders import StreamEncoder
+from .headers import Headers
+from .request import Request
+from .status_codes import StatusCodes
+from .tls import TLSResponse
+
+__all__ = ["Response"]
+
+T = TypeVar("T", bound="Response")
+
+REDIRECT_STATUS = (
+    StatusCodes.MOVED_PERMANENTLY,  # 301
+    StatusCodes.FOUND,  # 302
+    StatusCodes.SEE_OTHER,  # 303
+    StatusCodes.TEMPORARY_REDIRECT,  # 307
+    StatusCodes.PERMANENT_REDIRECT,  # 308
+)
+
+
+class Response:
+    def __init__(
+        self,
+        status_code: int,
+        *,
+        headers: HeaderTypes = None,
+        cookies: CookieTypes = None,
+        request: Union[Request] = None,
+        history: ResponseHistory = None,
+        body: bytes = None,
+        stream: StreamEncoder = None,
+        default_encoding: Union[str, Callable] = "utf-8",
+    ) -> None:
+        self._content = None
+        self._elapsed = None
+        self._encoding = None
+        self._text = None
+        self._response_id = None
+        self._http_version = None
+        self._request: Optional[Request] = request
+        self._cookies = Cookies(cookies)
+        self._is_stream_consumed = False
+        self._is_closed = False
+        self._next: Optional[Request] = None
+        self.headers = Headers(headers)
+        self.status_code = status_code
+        self.history = history if isinstance(history, list) else []
+        self.default_encoding = default_encoding
+        if isinstance(stream, StreamEncoder):
+            self.stream = stream
+        else:
+            self.stream = StreamEncoder.from_bytes(body or b"", chunk_size=CHUNK_SIZE)
+
+    @property
+    def id(self) -> str:
+        return self._response_id
+
+    @property
+    def elapsed(self) -> datetime.timedelta:
+        return self._elapsed
+
+    @elapsed.setter
+    def elapsed(self, elapsed: datetime.timedelta) -> None:
+        self._elapsed = elapsed
+
+    @property
+    def request(self) -> Request:
+        if self._request is None:
+            raise RuntimeError("The request instance has not been set on this response.")
+        return self._request
+
+    @request.setter
+    def request(self, value: Request) -> None:
+        self._request = value
+
+    @property
+    def next(self):
+        return self._next
+
+    @next.setter
+    def next(self, value: Request) -> None:
+        if isinstance(value, Request):
+            self._next = value
+
+    @property
+    def http_version(self) -> str:
+        return self._http_version or "HTTP/1.1"
+
+    @property
+    def cookies(self) -> Cookies:
+        if self._request:
+            # Fix missing domain in cookies by backfilling from request URL
+            # Ref: https://github.com/thewebscraping/tls-requests/issues/47
+            for cookie in self._cookies.cookiejar:
+                if not cookie.domain:
+                    cookie.domain = self._request.url.host
+                    cookie.domain_specified = False
+                    cookie.domain_initial_dot = False
+        return self._cookies
+
+    @property
+    def reason(self) -> str:
+        if self.status_code == 0:
+            return self.text or StatusCodes.get_reason(self.status_code)
+        return StatusCodes.get_reason(self.status_code)
+
+    @property
+    def url(self):
+        return self.request.url
+
+    @property
+    def content(self) -> bytes:
+        return self._content
+
+    @property
+    def text(self) -> str:
+        if self._text is None:
+            self._text = ""
+            if self.content:
+                decoder = codecs.getincrementaldecoder(self.encoding)(errors="replace")
+                self._text = decoder.decode(self.content)
+        return self._text
+
+    @property
+    def charset(self) -> Optional[str]:
+        if self.headers.get("Content-Type"):
+            msg = Message()
+            msg["content-type"] = self.headers["Content-Type"]
+            return msg.get_content_charset(failobj=None)
+        return None
+
+    @property
+    def encoding(self) -> str:
+        if self._encoding is None:
+            encoding = self.charset
+            if encoding is None:
+                if isinstance(self.default_encoding, str):
+                    try:
+                        codecs.lookup(self.default_encoding)
+                        encoding = self.default_encoding
+                    except LookupError:
+                        pass
+
+                if not encoding and chardet and self.content:
+                    encoding = chardet.detect(self.content)["encoding"]
+
+            self._encoding = encoding or "utf-8"
+        return self._encoding
+
+    @property
+    def ok(self) -> bool:
+        try:
+            self.raise_for_status()
+        except HTTPError:
+            return False
+        return True
+
+    def __bool__(self) -> bool:
+        return self.ok
+
+    @property
+    def is_redirect(self) -> bool:
+        return "Location" in self.headers and self.status_code in REDIRECT_STATUS
+
+    @property
+    def is_permanent_redirect(self):
+        return "Location" in self.headers and self.status_code in (
+            StatusCodes.MOVED_PERMANENTLY,
+            StatusCodes.PERMANENT_REDIRECT,
+        )
+
+    def raise_for_status(self) -> "Response":
+        http_error_msg = ""
+        if self.status_code < 100:
+            http_error_msg = "{0} TLS Client Error: {1} for url: {2}"
+
+        elif 400 <= self.status_code < 500:
+            http_error_msg = "{0} Client Error: {1} for url: {2}"
+
+        elif 500 <= self.status_code < 600:
+            http_error_msg = "{0} Server Error: {1} for url: {2}"
+
+        if http_error_msg:
+            raise HTTPError(
+                http_error_msg.format(
+                    self.status_code,
+                    (self.reason if self.status_code < 100 else StatusCodes.get_reason(self.status_code)),
+                    self.url,
+                ),
+                response=self,
+            )
+
+        return self
+
+    def json(self, **kwargs: Any) -> Any:
+        return to_json(self.text, **kwargs)
+
+    def __repr__(self) -> str:
+        return f"<Response [{self.status_code}]>"
+
+    def read(self) -> bytes:
+        with self.stream as stream:
+            self._content = b"".join(stream.render())
+            return self._content
+
+    async def aread(self) -> bytes:
+        with self.stream as stream:
+            self._content = b"".join([chunk async for chunk in stream])
+            return self._content
+
+    @property
+    def closed(self):
+        return self._is_closed
+
+    def close(self) -> None:
+        if not self._is_closed:
+            self._is_closed = True
+            self._is_stream_consumed = True
+            self.stream.close()
+
+        # Fix pickle dump
+        # Ref: https://github.com/thewebscraping/tls-requests/issues/35
+        self.stream = None
+
+    async def aclose(self) -> None:
+        return self.close()
+
+    @classmethod
+    def from_tls_response(cls, response: TLSResponse, is_byte_response: bool = False) -> "Response":
+        def _parse_response_body(value: Optional[str]) -> bytes:
+            if value:
+                if is_byte_response and response.status > 0:
+                    try:
+                        value = b64decode(value.split(",")[-1])
+                        return value
+                    except (binascii.Error, AssertionError):
+                        raise Base64DecodeError("Couldn't decode the base64 string into bytes.")
+                return value.encode("utf-8")
+            return b""
+
+        ret = cls(
+            status_code=response.status,
+            body=_parse_response_body(response.body),
+            headers=response.headers,
+            cookies=response.cookies,
+        )
+        ret._response_id = response.id
+        ret._http_version = response.usedProtocol
+        return ret

--- a/vendor/tls_requests/models/rotators.py
+++ b/vendor/tls_requests/models/rotators.py
@@ -1,0 +1,545 @@
+from __future__ import annotations
+
+import asyncio
+import itertools
+import json
+import random
+import threading
+from abc import ABC, abstractmethod
+from pathlib import Path
+from typing import (Any, Generic, Iterable, Iterator, List, Literal, Optional,
+                    TypeVar, Union)
+
+from ..exceptions import RotatorError
+from ..types import HeaderTypes, TLSIdentifierTypes
+from .headers import Headers
+from .urls import Proxy
+
+T = TypeVar("T")
+
+TLS_IDENTIFIER_TEMPLATES = [
+    "chrome_120",
+    "chrome_124",
+    "chrome_131",
+    "chrome_133",
+    "firefox_120",
+    "firefox_123",
+    "firefox_132",
+    "firefox_133",
+    "safari_16_0",
+    "safari_ios_16_0",
+    "safari_ios_17_0",
+    "safari_ios_18_0",
+    "safari_ios_18_5",
+]
+
+USER_AGENTS = [
+    "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36",
+    "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/121.0.0.0 Safari/537.36",
+    "Mozilla/5.0 (Windows NT 11.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36",
+    (
+        "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0"
+        " Safari/537.36"
+    ),
+    (
+        "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/121.0.0.0"
+        " Safari/537.36"
+    ),
+    (
+        "Mozilla/5.0 (Macintosh; Intel Mac OS X 14_2_1) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0"
+        " Safari/537.36"
+    ),
+    "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36",
+    "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/121.0.0.0 Safari/537.36",
+    "Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:121.0) Gecko/20100101 Firefox/121.0",
+    "Mozilla/5.0 (Macintosh; Intel Mac OS X 10.15; rv:121.0) Gecko/20100101 Firefox/121.0",
+    "Mozilla/5.0 (X11; Linux x86_64; rv:121.0) Gecko/20100101 Firefox/121.0",
+    "Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:122.0) Gecko/20100101 Firefox/122.0",
+    (
+        "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.2"
+        " Safari/605.1.15"
+    ),
+    (
+        "Mozilla/5.0 (Macintosh; Intel Mac OS X 14_2_1) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.2"
+        " Safari/605.1.15"
+    ),
+    (
+        "Mozilla/5.0 (iPhone; CPU iPhone OS 17_2 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.2"
+        " Mobile/15E148 Safari/604.1"
+    ),
+    (
+        "Mozilla/5.0 (iPad; CPU OS 17_2 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.2"
+        " Mobile/15E148 Safari/604.1"
+    ),
+    (
+        "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0"
+        " Safari/537.36 Edg/120.0.0.0"
+    ),
+    (
+        "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0"
+        " Safari/537.36 Edg/120.0.0.0"
+    ),
+    (
+        "Mozilla/5.0 (Linux; Android 14; SM-G998B) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Mobile"
+        " Safari/537.36"
+    ),
+    (
+        "Mozilla/5.0 (Linux; Android 14; SM-S918B) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/121.0.0.0 Mobile"
+        " Safari/537.36"
+    ),
+    (
+        "Mozilla/5.0 (iPhone; CPU iPhone OS 17_1 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.1"
+        " Mobile/15E148 Safari/604.1"
+    ),
+    (
+        "Mozilla/5.0 (Linux; Android 15; SM-S931B Build/AP3A.240905.015.A2; wv) AppleWebKit/537.36 (KHTML, like Gecko)"
+        " Version/4.0 Chrome/127.0.6533.103 Mobile Safari/537.36"
+    ),
+    (
+        "Mozilla/5.0 (Linux; Android 14; SM-S928B/DS) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.6099.230"
+        " Mobile Safari/537.36"
+    ),
+    (
+        "Mozilla/5.0 (Linux; Android 14; SM-F956U) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0"
+        " Chrome/80.0.3987.119 Mobile Safari/537.36"
+    ),
+    (
+        "Mozilla/5.0 (Linux; Android 13; SM-S911U) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/110.0.0.0 Mobile"
+        " Safari/537.36"
+    ),
+    (
+        "Mozilla/5.0 (Linux; Android 13; SM-S901B) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/112.0.0.0 Mobile"
+        " Safari/537.36"
+    ),
+    (
+        "Mozilla/5.0 (Linux; Android 13; SM-S908U) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/111.0.0.0 Mobile"
+        " Safari/537.36"
+    ),
+    (
+        "Mozilla/5.0 (Linux; Android 13; SM-G991B) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/112.0.0.0 Mobile"
+        " Safari/537.36"
+    ),
+    (
+        "Mozilla/5.0 (Linux; Android 13; SM-G998U) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/112.0.0.0 Mobile"
+        " Safari/537.36"
+    ),
+    (
+        "Mozilla/5.0 (Linux; Android 14; Pixel 9 Pro Build/AD1A.240418.003; wv) AppleWebKit/537.36 (KHTML, like Gecko)"
+        " Version/4.0 Chrome/124.0.6367.54 Mobile Safari/537.36"
+    ),
+    (
+        "Mozilla/5.0 (Linux; Android 14; Pixel 9 Build/AD1A.240411.003.A5; wv) AppleWebKit/537.36 (KHTML, like Gecko)"
+        " Version/4.0 Chrome/124.0.6367.54 Mobile Safari/537.36"
+    ),
+    (
+        "Mozilla/5.0 (Linux; Android 15; Pixel 8 Pro Build/AP4A.250105.002; wv) AppleWebKit/537.36 (KHTML, like Gecko)"
+        " Version/4.0 Chrome/132.0.6834.163 Mobile Safari/537.36"
+    ),
+    (
+        "Mozilla/5.0 (Linux; Android 15; Pixel 8 Build/AP4A.250105.002; wv) AppleWebKit/537.36 (KHTML, like Gecko)"
+        " Version/4.0 Chrome/132.0.6834.163 Mobile Safari/537.36"
+    ),
+    (
+        "Mozilla/5.0 (Linux; Android 13; Pixel 7 Pro) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/112.0.0.0 Mobile"
+        " Safari/537.36"
+    ),
+    (
+        "Mozilla/5.0 (Linux; Android 13; Pixel 7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/112.0.0.0 Mobile"
+        " Safari/537.36"
+    ),
+    (
+        "Mozilla/5.0 (Linux; Android 15; moto g - 2025 Build/V1VK35.22-13-2; wv) AppleWebKit/537.36 (KHTML, like Gecko)"
+        " Version/4.0 Chrome/132.0.6834.163 Mobile Safari/537.36"
+    ),
+    (
+        "Mozilla/5.0 (Linux; Android 13; 23129RAA4G Build/TKQ1.221114.001; wv) AppleWebKit/537.36 (KHTML, like Gecko)"
+        " Version/4.0 Chrome/116.0.0.0 Mobile Safari/537.36"
+    ),
+    (
+        "Mozilla/5.0 (Linux; Android 15; 24129RT7CC Build/AP3A.240905.015.A2; wv) AppleWebKit/537.36 (KHTML, like"
+        " Gecko) Version/4.0 Chrome/130.0.6723.86 Mobile Safari/537.36"
+    ),
+    (
+        "Mozilla/5.0 (Linux; Android 12; HBP-LX9 Build/HUAWEIHBP-L29; wv) AppleWebKit/537.36 (KHTML, like Gecko)"
+        " Version/4.0 Chrome/99.0.4844.88 Mobile Safari/537.36"
+    ),
+    (
+        "Mozilla/5.0 (Linux; U; Android 12; zh-Hans-CN; ADA-AL00 Build/HUAWEIADA-AL00) AppleWebKit/537.36 (KHTML, like"
+        " Gecko) Version/4.0 Chrome/100.0.4896.58 Quark/6.11.2.531 Mobile Safari/537.36"
+    ),
+    (
+        "Mozilla/5.0 (Linux; Android 12; PSD-AL00 Build/HUAWEIPSD-AL00; wv) AppleWebKit/537.36 (KHTML, like Gecko)"
+        " Version/4.0 Chrome/99.0.4844.88 Mobile Safari/537.36"
+    ),
+    (
+        "Mozilla/5.0 (Linux; Android 14; 24030PN60G Build/UKQ1.231003.002; wv) AppleWebKit/537.36 (KHTML, like Gecko)"
+        " Version/4.0 Chrome/122.0.6261.119 Mobile Safari/537.36"
+    ),
+    (
+        "Mozilla/5.0 (Linux; Android 10; VOG-L29) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/112.0.0.0 Mobile"
+        " Safari/537.36"
+    ),
+    (
+        "Mozilla/5.0 (Linux; Android 10; MAR-LX1A) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/112.0.0.0 Mobile"
+        " Safari/537.36"
+    ),
+]
+
+HEADER_TEMPLATES = [
+    {
+        "accept": "*/*",
+        "connection": "keep-alive",
+        "accept-encoding": "gzip, deflate, br, zstd",
+        "User-Agent": ua,
+    }
+    for ua in USER_AGENTS
+]
+
+
+class BaseRotator(ABC, Generic[T]):
+    """
+    A unified, thread-safe and coroutine-safe abstract base class for a
+    generic rotating data source.
+
+    This class provides a dual API for both synchronous and asynchronous contexts.
+    - For synchronous, thread-safe operations, use methods like `next()`, `add()`.
+    - For asynchronous, coroutine-safe operations, use methods prefixed with 'a',
+      like `anext()`, `aadd()`.
+
+    It uses a `threading.Lock` for thread safety and an `asyncio.Lock` for
+    coroutine safety.
+
+    Attributes:
+        items (List[T]): The list of items to rotate through.
+        strategy (str): The rotation strategy in use.
+    """
+
+    def __init__(
+        self,
+        items: Optional[Iterable[T]] = None,
+        strategy: Literal["round_robin", "random", "weighted"] = "random",
+    ) -> None:
+        """
+        Initializes the BaseRotator.
+
+        Args:
+            items: An iterable of initial items.
+            strategy: The rotation strategy to use.
+        """
+        self.items: List[T] = list(items or [])
+        self.strategy = strategy
+        self._iterator: Optional[Iterator[T]] = None
+        self._lock = threading.Lock()
+        self._async_lock = asyncio.Lock()
+        self._rebuild_iterator()
+
+    @classmethod
+    def from_file(
+        cls,
+        source: Union[str, Path, list],
+        strategy: Literal["round_robin", "random", "weighted"] = "random",
+    ) -> "BaseRotator":
+        """
+        Factory method to create a rotator from a file or a list. This method
+        is synchronous as it's typically used during setup.
+        """
+
+        items = []
+        if isinstance(source, (str, Path)):
+            path = Path(source)
+            if not path.exists():
+                raise FileNotFoundError(f"Source file not found: {path}")
+
+            if path.suffix == ".json":
+                data = json.loads(path.read_text())
+                items = [cls.rebuild_item(item) for item in data]
+            else:
+                lines = path.read_text().splitlines()
+                for line in lines:
+                    line_content = line.split("#", 1)[0].strip()
+                    if not line_content:
+                        continue
+                    items.append(cls.rebuild_item(line_content))
+        elif isinstance(source, list):
+            items = [cls.rebuild_item(item) for item in source]
+        else:
+            raise RotatorError(f"Unsupported source type: {type(source)}")
+
+        valid_items = [item for item in items if item is not None]
+        return cls(valid_items, strategy)
+
+    @classmethod
+    @abstractmethod
+    def rebuild_item(cls, item: Any) -> Optional[T]:
+        """
+        Abstract method to convert a raw item into a typed object. Must be
+        implemented by subclasses.
+        """
+        raise NotImplementedError
+
+    def _rebuild_iterator(self) -> None:
+        """
+        Reconstructs the internal iterator. This is a core logic method and
+        should be called only after acquiring a lock.
+        """
+        if not self.items:
+            self._iterator = None
+            return
+
+        if self.strategy == "round_robin":
+            self._iterator = itertools.cycle(self.items)
+        elif self.strategy == "random":
+            self._iterator = None
+        elif self.strategy == "weighted":
+            weights = [getattr(item, "weight", 1.0) for item in self.items]
+            self._iterator = self._weighted_cycle(self.items, weights)
+        else:
+            raise ValueError(f"Unsupported strategy: {self.strategy}")
+
+    def _weighted_cycle(self, items: List[T], weights: List[float]) -> Iterator[T]:
+        """Creates an infinite iterator that yields items based on weights."""
+        while True:
+            yield random.choices(items, weights=weights, k=1)[0]
+
+    def next(self, *args, **kwargs) -> T:
+        """
+        Retrieves the next item using a thread-safe mechanism.
+
+        Returns:
+            The next item from the collection.
+
+        Raises:
+            ValueError: If the rotator contains no items.
+        """
+        with self._lock:
+            if not self.items:
+                raise ValueError("Rotator is empty.")
+            if self.strategy == "random":
+                return random.choice(self.items)
+            return next(self._iterator)
+
+    def add(self, item: T) -> None:
+        """
+        Adds a new item to the rotator in a thread-safe manner.
+        """
+        with self._lock:
+            self.items.append(item)
+            self._rebuild_iterator()
+
+    def remove(self, item: T) -> None:
+        """
+        Removes an item from the rotator in a thread-safe manner.
+        """
+        with self._lock:
+            self.items = [i for i in self.items if i != item]
+            self._rebuild_iterator()
+
+    async def anext(self, *args, **kwargs) -> T:
+        """
+        Retrieves the next item using a coroutine-safe mechanism.
+
+        Returns:
+            The next item from the collection.
+
+        Raises:
+            ValueError: If the rotator contains no items.
+        """
+        async with self._async_lock:
+            if not self.items:
+                raise ValueError("Rotator is empty.")
+            if self.strategy == "random":
+                return random.choice(self.items)
+            return next(self._iterator)
+
+    async def aadd(self, item: T) -> None:
+        """
+        Adds a new item to the rotator in a coroutine-safe manner.
+        """
+        async with self._async_lock:
+            self.items.append(item)
+            self._rebuild_iterator()
+
+    async def aremove(self, item: T) -> None:
+        """
+        Removes an item from the rotator in a coroutine-safe manner.
+        """
+        async with self._async_lock:
+            self.items = [i for i in self.items if i != item]
+            self._rebuild_iterator()
+
+    def __len__(self) -> int:
+        return len(self.items)
+
+    def __iter__(self) -> Iterator[T]:
+        return iter(self.items)
+
+
+class ProxyRotator(BaseRotator[Proxy]):
+    """
+    A unified rotator for managing `Proxy` objects, supporting both sync and
+    async operations.
+    """
+
+    @classmethod
+    def rebuild_item(cls, item: Any) -> Optional[Proxy]:
+        """Constructs a `Proxy` object from various input types."""
+        try:
+            if isinstance(item, Proxy):
+                return item
+            if isinstance(item, dict):
+                return Proxy.from_dict(item)
+            if isinstance(item, str):
+                return Proxy.from_string(item)
+        except Exception:
+            return None
+        return None
+
+    def mark_result(self, proxy: Proxy, success: bool, latency: Optional[float] = None) -> None:
+        """
+        Thread-safely updates a proxy's performance statistics.
+        """
+        with self._lock:
+            self._update_proxy_stats(proxy, success, latency)
+
+    async def amark_result(self, proxy: Proxy, success: bool, latency: Optional[float] = None) -> None:
+        """
+        Coroutine-safely updates a proxy's performance statistics.
+        """
+        async with self._async_lock:
+            self._update_proxy_stats(proxy, success, latency)
+
+    def _update_proxy_stats(self, proxy: Proxy, success: bool, latency: Optional[float] = None):
+        """Internal logic for updating proxy stats. Must be called from a locked context."""
+        if success:
+            proxy.mark_success(latency)
+        else:
+            proxy.mark_failed()
+
+        if self.strategy == "weighted":
+            self._rebuild_iterator()
+
+
+class TLSIdentifierRotator(BaseRotator[TLSIdentifierTypes]):
+    """
+    A unified rotator for TLS Identifiers, supporting both sync and async operations.
+    """
+
+    def __init__(
+        self,
+        items: Optional[Iterable[T]] = None,
+        strategy: Literal["round_robin", "random", "weighted"] = "round_robin",
+    ) -> None:
+        super().__init__(items or TLS_IDENTIFIER_TEMPLATES, strategy)
+
+    @classmethod
+    def rebuild_item(cls, item: Any) -> Optional[TLSIdentifierTypes]:
+        """Processes a raw item to be used as a TLS identifier."""
+        if isinstance(item, str):
+            return item
+        return None
+
+
+class HeaderRotator(BaseRotator[Headers]):
+    """
+    A unified rotator for managing `Headers` objects, supporting both sync and
+    async operations.
+
+    This rotator can dynamically update the 'User-Agent' header for each request
+    without modifying the original header templates.
+
+    Examples:
+        >>> common_headers = {
+        ...     "Accept": "application/json",
+        ...     "Accept-Language": "en-US,en;q=0.9",
+        ...     "User-Agent": "Default-Bot/1.0"
+        ... }
+        >>> mobile_headers = {
+        ...     "Accept": "*/*",
+        ...     "User-Agent": "Default-Mobile/1.0",
+        ...     "X-Custom-Header": "mobile"
+        ... }
+        >>>
+        >>> rotator = HeaderRotator.from_file([common_headers, mobile_headers])
+        >>>
+        >>> # Get headers without modification
+        >>> h1 = rotator.next()
+        >>> print(h1['User-Agent'])
+        Default-Bot/1.0
+        >>>
+        >>> # Get headers with a new, dynamic User-Agent
+        >>> h2 = rotator.next(user_agent="My-Custom-UA/2.0")
+        >>> print(h2['User-Agent'])
+        My-Custom-UA/2.0
+        >>>
+        >>> # The original header set remains unchanged
+        >>> h3 = rotator.next()
+        >>> print(h3['User-Agent'])
+        Default-Mobile/1.0
+    """
+
+    def __init__(
+        self,
+        items: Optional[Iterable[T]] = None,
+        strategy: Literal["round_robin", "random", "weighted"] = "random",
+    ) -> None:
+        super().__init__(items or HEADER_TEMPLATES, strategy)
+
+    @classmethod
+    def rebuild_item(cls, item: HeaderTypes) -> Optional[Headers]:
+        """
+        Constructs a `Headers` object from various input types.
+
+        It can process existing `Headers` objects, dictionaries, or lists of tuples.
+
+        Args:
+            item: The raw data to convert into a `Headers` object.
+
+        Returns:
+            A `Headers` instance, or None if the input is invalid.
+        """
+        try:
+            if isinstance(item, Headers):
+                return item
+            return Headers(item)
+        except Exception:
+            return None
+
+    def next(self, user_agent: Optional[str] = None, **kwargs) -> Headers:
+        """
+        Retrieves the next `Headers` object in a thread-safe manner and
+        optionally updates its User-Agent.
+
+        Args:
+            user_agent: If provided, this string will replace the 'User-Agent'
+                        header in the returned object.
+
+        Returns:
+            A copy of the next `Headers` object, potentially with a modified User-Agent.
+        """
+        headers = super().next()
+        headers_copy = headers.copy()
+        if not isinstance(headers_copy, Headers):
+            headers_copy = Headers(headers_copy)
+        if user_agent:
+            headers_copy["User-Agent"] = user_agent
+        return headers_copy
+
+    async def anext(self, user_agent: Optional[str] = None, **kwargs) -> Headers:
+        """
+        Retrieves the next `Headers` object in a coroutine-safe manner and
+        optionally updates its User-Agent.
+
+        Args:
+            user_agent: If provided, this string will replace the 'User-Agent'
+                        header in the returned object.
+
+        Returns:
+            A copy of the next `Headers` object, potentially with a modified User-Agent.
+        """
+        headers = await super().anext()
+        headers_copy = headers.copy()
+        if not isinstance(headers_copy, Headers):
+            headers_copy = Headers(headers_copy)
+        if user_agent:
+            headers_copy["User-Agent"] = user_agent
+        return headers_copy

--- a/vendor/tls_requests/models/status_codes.py
+++ b/vendor/tls_requests/models/status_codes.py
@@ -1,0 +1,89 @@
+from enum import Enum
+
+__all__ = ["StatusCodes"]
+
+
+class StatusCodes(int, Enum):
+    def __new__(cls, value: int, reason: str = ""):
+        obj = int.__new__(cls, value)
+        obj._value_ = value
+        obj.reason = reason
+        return obj
+
+    def __str__(self) -> str:
+        return str(self.value)
+
+    @classmethod
+    def get_reason(cls, value: int):
+        if value in cls._value2member_map_:
+            return cls._value2member_map_[value].reason
+        return "Unknown Error"
+
+    CONTINUE = 100, "Continue"
+    SWITCHING_PROTOCOLS = 101, "Switching Protocols"
+    PROCESSING = 102, "Processing"
+    CHECKPOINT = 103, "Checkpoint"
+    URI_TOO_LONG = 122, "Uri Too Long"
+    OK = 200, "OK"
+    CREATED = 201, "Created"
+    ACCEPTED = 202, "Accepted"
+    NON_AUTHORITATIVE_INFO = 203, "Non Authoritative Info"
+    NO_CONTENT = 204, "No Content"
+    RESET_CONTENT = 205, "Reset Content"
+    PARTIAL_CONTENT = 206, "Partial Content"
+    MULTI_STATUS = 207, "Multi Status"
+    ALREADY_REPORTED = 208, "Already Reported"
+    IM_USED = 226, "Im Used"
+    MULTIPLE_CHOICES = 300, "Multiple Choices"
+    MOVED_PERMANENTLY = 301, "Moved Permanently"
+    FOUND = 302, "Found"
+    SEE_OTHER = 303, "See Other"
+    NOT_MODIFIED = 304, "Not Modified"
+    USE_PROXY = 305, "Use Proxy"
+    SWITCH_PROXY = 306, "Switch Proxy"
+    TEMPORARY_REDIRECT = 307, "Temporary Redirect"
+    PERMANENT_REDIRECT = 308, "Permanent Redirect"
+    BAD_REQUEST = 400, "Bad Request"
+    UNAUTHORIZED = 401, "Unauthorized"
+    PAYMENT_REQUIRED = 402, "Payment Required"
+    FORBIDDEN = 403, "Forbidden"
+    NOT_FOUND = 404, "Not Found"
+    METHOD_NOT_ALLOWED = 405, "Method Not Allowed"
+    NOT_ACCEPTABLE = 406, "Not Acceptable"
+    PROXY_AUTHENTICATION_REQUIRED = 407, "Proxy Authentication Required"
+    REQUEST_TIMEOUT = 408, "Request Timeout"
+    CONFLICT = 409, "Conflict"
+    GONE = 410, "Gone"
+    LENGTH_REQUIRED = 411, "Length Required"
+    PRECONDITION_FAILED = 412, "Precondition Failed"
+    REQUEST_ENTITY_TOO_LARGE = 413, "Request Entity Too Large"
+    REQUEST_URI_TOO_LARGE = 414, "Request Uri Too Large"
+    UNSUPPORTED_MEDIA_TYPE = 415, "Unsupported Media Type"
+    REQUESTED_RANGE_NOT_SATISFIABLE = 416, "Requested Range Not Satisfiable"
+    EXPECTATION_FAILED = 417, "Expectation Failed"
+    IM_A_TEAPOT = 418, "Im A Teapot"
+    MISDIRECTED_REQUEST = 421, "Misdirected Request"
+    UNPROCESSABLE_ENTITY = 422, "Unprocessable Entity"
+    LOCKED = 423, "Locked"
+    FAILED_DEPENDENCY = 424, "Failed Dependency"
+    UNORDERED_COLLECTION = 425, "Unordered Collection"
+    UPGRADE_REQUIRED = 426, "Upgrade Required"
+    PRECONDITION_REQUIRED = 428, "Precondition Required"
+    TOO_MANY_REQUESTS = 429, "Too Many Requests"
+    HEADER_FIELDS_TOO_LARGE = 431, "Header Fields Too Large"
+    NO_RESPONSE = 444, "No Response"
+    RETRY_WITH = 449, "Retry With"
+    BLOCKED_BY_WINDOWS_PARENTAL_CONTROLS = 450, "Blocked By Windows Parental Controls"
+    UNAVAILABLE_FOR_LEGAL_REASONS = 451, "Unavailable For Legal Reasons"
+    CLIENT_CLOSED_REQUEST = 499, "Client Closed Request"
+    INTERNAL_SERVER_ERROR = 500, "Internal Server Error"
+    NOT_IMPLEMENTED = 501, "Not Implemented"
+    BAD_GATEWAY = 502, "Bad Gateway"
+    SERVICE_UNAVAILABLE = 503, "Service Unavailable"
+    GATEWAY_TIMEOUT = 504, "Gateway Timeout"
+    HTTP_VERSION_NOT_SUPPORTED = 505, "Http Version Not Supported"
+    VARIANT_ALSO_NEGOTIATES = 506, "Variant Also Negotiates"
+    INSUFFICIENT_STORAGE = 507, "Insufficient Storage"
+    BANDWIDTH_LIMIT_EXCEEDED = 509, "Bandwidth Limit Exceeded"
+    NOT_EXTENDED = 510, "Not Extended"
+    NETWORK_AUTHENTICATION_REQUIRED = 511, "Network Authentication Required"

--- a/vendor/tls_requests/models/tls.py
+++ b/vendor/tls_requests/models/tls.py
@@ -1,0 +1,542 @@
+import ctypes
+import uuid
+from dataclasses import asdict, dataclass, field
+from dataclasses import fields as get_fields
+from typing import Any, List, Mapping, Optional, Set, TypeVar, Union
+
+from ..settings import (DEFAULT_HEADERS, DEFAULT_TIMEOUT, DEFAULT_TLS_DEBUG,
+                        DEFAULT_TLS_HTTP2, DEFAULT_TLS_IDENTIFIER)
+from ..types import (MethodTypes, TLSCookiesTypes, TLSIdentifierTypes,
+                     TLSSessionId, URLTypes)
+from ..utils import to_base64, to_bytes, to_json
+from .encoders import StreamEncoder
+from .libraries import TLSLibrary
+from .status_codes import StatusCodes
+
+__all__ = [
+    "TLSClient",
+    "TLSResponse",
+    "TLSConfig",
+    "CustomTLSClientConfig",
+]
+
+T = TypeVar("T", bound="_BaseConfig")
+
+
+class TLSClient:
+    """TLSClient
+
+    The `TLSClient` class provides a high-level interface for performing secure TLS-based HTTP operations. It encapsulates
+    interactions with a custom TLS library, offering functionality for managing sessions, cookies, and HTTP requests.
+    This class is designed to be extensible and integrates seamlessly with the `TLSResponse` and `TLSConfig` classes
+    for handling responses and configuring requests.
+
+    Attributes:
+        _library (Optional): Reference to the loaded TLS library.
+        _getCookiesFromSession (Optional): Function for retrieving cookies from a session.
+        _addCookiesToSession (Optional): Function for adding cookies to a session.
+        _destroySession (Optional): Function for destroying a specific session.
+        _destroyAll (Optional): Function for destroying all active sessions.
+        _request (Optional): Function for performing a TLS-based HTTP request.
+        _freeMemory (Optional): Function for freeing allocated memory for responses.
+
+    Methods:
+        setup(cls):
+            Loads and sets up the TLS library and initializes function bindings.
+
+        get_cookies(cls, session_id: TLSSessionId, url: str) -> TLSResponse:
+            Retrieves cookies from a session for the given URL.
+
+        add_cookies(cls, session_id: TLSSessionId, payload: dict):
+            Adds cookies to a specific session.
+
+        destroy_all(cls) -> bool:
+            Destroys all active TLS sessions. Returns `True` if successful.
+
+        destroy_session(cls, session_id: TLSSessionId) -> bool:
+            Destroys a specific TLS session. Returns `True` if successful.
+
+        request(cls, payload):
+            Performs a TLS-based HTTP request with the provided payload.
+
+        free_memory(cls, response_id: str) -> None:
+            Frees the memory allocated for a specific response.
+
+        response(cls, raw: bytes) -> TLSResponse:
+            Processes a raw byte response and returns a `TLSResponse` object.
+
+        _make_request(cls, fn: callable, payload: dict):
+            Helper method to handle request processing and response generation.
+
+    Example:
+        Initialize the client and perform operations:
+
+        >>> from tls_requests.tls import TLSClient
+        >>> client = TLSClient.initialize()
+        >>> session_id = "my-session-id"
+        >>> url = "https://example.com"
+        >>> response = client.get_cookies(session_id, url)
+        >>> print(response)
+    """
+
+    _library = None
+    _getCookiesFromSession = None
+    _addCookiesToSession = None
+    _destroySession = None
+    _destroyAll = None
+    _request = None
+    _freeMemory = None
+
+    def __init__(self) -> None:
+        if self._library is None:
+            self.initialize()
+
+    @classmethod
+    def initialize(cls):
+        cls._library = TLSLibrary.load()
+        for name in [
+            "getCookiesFromSession",
+            "addCookiesToSession",
+            "destroySession",
+            "freeMemory",
+            "request",
+        ]:
+            fn_name = "_%s" % name
+            setattr(cls, fn_name, getattr(cls._library, name, None))
+            fn = getattr(cls, fn_name, None)
+            if fn and callable(fn):
+                fn.argtypes = [ctypes.c_char_p]
+                fn.restype = ctypes.c_char_p
+
+        cls._destroyAll = cls._library.destroyAll
+        cls._destroyAll.restype = ctypes.c_char_p
+        return cls()
+
+    @classmethod
+    def get_cookies(cls, session_id: TLSSessionId, url: str) -> "TLSResponse":
+        response = cls._send(cls._getCookiesFromSession, {"sessionId": session_id, "url": url})
+        return response
+
+    @classmethod
+    def add_cookies(cls, session_id: TLSSessionId, payload: dict):
+        payload["sessionId"] = session_id
+        return cls._send(
+            cls._addCookiesToSession,
+            payload,
+        )
+
+    @classmethod
+    def destroy_all(cls) -> bool:
+        response = TLSResponse.from_bytes(cls._destroyAll())
+        if response.success:
+            return True
+        return False
+
+    @classmethod
+    def destroy_session(cls, session_id: TLSSessionId) -> bool:
+        response = cls._send(cls._destroySession, {"sessionId": session_id})
+        return response.success or False
+
+    @classmethod
+    def request(cls, payload):
+        return cls._send(cls._request, payload)
+
+    @classmethod
+    def free_memory(cls, response_id: str) -> None:
+        cls._freeMemory(to_bytes(response_id))
+
+    @classmethod
+    def response(cls, raw: bytes) -> "TLSResponse":
+        response = TLSResponse.from_bytes(raw)
+        cls.free_memory(response.id)
+        return response
+
+    @classmethod
+    async def aresponse(cls, raw: bytes):
+        with StreamEncoder.from_bytes(raw) as stream:
+            content = b"".join([chunk async for chunk in stream])
+            return TLSResponse.from_kwargs(**to_json(content))
+
+    @classmethod
+    async def arequest(cls, payload):
+        return await cls._aread(cls._request, payload)
+
+    @classmethod
+    def _send(cls, fn: callable, payload: dict):
+        return cls.response(fn(to_bytes(payload)))
+
+    @classmethod
+    async def _aread(cls, fn: callable, payload: dict):
+        return await cls.aresponse(fn(to_bytes(payload)))
+
+
+@dataclass
+class _BaseConfig:
+    """Base configuration for TLSSession"""
+
+    @classmethod
+    def model_fields_set(cls) -> Set[str]:
+        return {model_field.name for model_field in get_fields(cls) if not model_field.name.startswith("_")}
+
+    @classmethod
+    def from_kwargs(cls, **kwargs: Any) -> T:
+        model_fields_set = cls.model_fields_set()
+        return cls(**{k: v for k, v in kwargs.items() if k in model_fields_set and v})  # noqa
+
+    def to_dict(self) -> dict:
+        return {k: v for k, v in asdict(self).items() if not k.startswith("_")}
+
+    def to_payload(self) -> dict:
+        return self.to_dict()
+
+
+@dataclass
+class TLSResponse(_BaseConfig):
+    """TLS Response
+
+    Attributes:
+        id (Optional[str]): A unique identifier for the response. Defaults to `None`.
+        sessionId (Optional[str]): The session ID associated with the response. Defaults to `None`.
+        status (Optional[int]): The HTTP status code of the response. Defaults to `0`.
+        target (Optional[str]): The target URL or endpoint of the response. Defaults to `None`.
+        body (Optional[str]): The body content of the response. Defaults to `None`.
+        headers (Optional[dict]): A dictionary containing the headers of the response. Defaults to an empty dictionary.
+        cookies (Optional[dict]): A dictionary containing the cookies of the response. Defaults to an empty dictionary.
+        success (Optional[bool]): Indicates if the response was successful. Defaults to `False`.
+        usedProtocol (Optional[str]): The protocol used in the response. Defaults to `"HTTP/1.1"`.
+
+    Methods:
+        from_bytes(cls, raw: bytes) -> TLSResponse:
+            Parses a raw byte stream and constructs a `TLSResponse` object.
+
+        reason_phrase -> str:
+            A property that provides the reason phrase associated with the HTTP status code.
+            If the status code is `0`, it returns `"Bad Request"`.
+    """
+
+    id: Optional[str] = None
+    sessionId: Optional[str] = None
+    status: Optional[int] = 0
+    target: Optional[str] = None
+    body: Optional[str] = None
+    headers: Optional[dict] = field(default_factory=dict)
+    cookies: Optional[dict] = field(default_factory=dict)
+    success: Optional[bool] = False
+    usedProtocol: Optional[str] = "HTTP/1.1"
+
+    @classmethod
+    def from_bytes(cls, raw: bytes) -> "TLSResponse":
+        with StreamEncoder.from_bytes(raw) as stream:
+            return cls.from_kwargs(**to_json(b"".join(stream)))
+
+    @property
+    def reason(self) -> str:
+        return StatusCodes.get_reason(self.status)
+
+    def __repr__(self):
+        return "<Response [%d]>" % self.status
+
+
+@dataclass
+class TLSRequestCookiesConfig(_BaseConfig):
+    """
+    Request Cookies Configuration
+
+    Represents a single request cookie with a _name and value.
+
+    Attributes:
+        name (str): The _name of the cookie.
+        value (str): The value of the cookie.
+
+    Example:
+        Create a `TLSRequestCookiesConfig` object:
+
+        >>> from tls_requests.tls import TLSRequestCookiesConfig
+        >>> kwargs = {
+        ...     "_name": "foo2",
+        ...     "value": "bar2",
+        ... }
+        >>> obj = TLSRequestCookiesConfig(**kwargs)
+    """
+
+    name: str
+    value: str
+
+
+@dataclass
+class CustomTLSClientConfig(_BaseConfig):
+    """
+    Custom TLS Client Configuration
+
+    The `CustomTLSClientConfig` class defines advanced configuration options for customizing TLS client behavior.
+    It includes support for ALPN, ALPS protocols, certificate compression, HTTP/2 settings, JA3 fingerprints, and
+    other TLS-related settings.
+
+    Attributes:
+        alpnProtocols (list[str], optional): ALPN protocols. Defaults to `None`.
+        alpsProtocols (list[str], optional): ALPS protocols. Defaults to `None`.
+        certCompressionAlgo (str, optional): Certificate compression algorithm. Defaults to `None`.
+        connectionFlow (int, optional): Connection flow. Defaults to `None`.
+        h2Settings (list[str], optional): HTTP/2 settings. Defaults to `None`.
+        h2SettingsOrder (list[str], optional): Order of HTTP/2 settings. Defaults to `None`.
+        headerPriority (list[str], optional): Priority of headers. Defaults to `None`.
+        ja3String (str, optional): JA3 string. Defaults to `None`.
+        keyShareCurves (list[str], optional): Key share curves. Defaults to `None`.
+        priorityFrames (list[str], optional): Priority of frames. Defaults to `None`.
+        pseudoHeaderOrder (list[str], optional): Order of pseudo headers. Defaults to `None`.
+        supportedSignatureAlgorithms (list[str], optional): Supported signature algorithms. Defaults to `None`.
+        supportedVersions (list[str], optional): Supported versions. Defaults to `None`.
+
+    Example:
+        Create a `CustomTLSClientConfig` instance with specific settings:
+
+        >>> from tls_requests.tls import CustomTLSClientConfig
+        >>> kwargs = {
+        ...     "alpnProtocols": ["h2", "http/1.1"],
+        ...     "alpsProtocols": ["h2"],
+        ...     "certCompressionAlgo": "brotli",
+        ...     "connectionFlow": 15663105,
+        ...     "h2Settings": {
+        ...         "HEADER_TABLE_SIZE": 65536,
+        ...         "MAX_CONCURRENT_STREAMS": 1000,
+        ...         "INITIAL_WINDOW_SIZE": 6291456,
+        ...         "MAX_HEADER_LIST_SIZE": 262144
+        ...     },
+        ...     "h2SettingsOrder": [
+        ...         "HEADER_TABLE_SIZE",
+        ...         "MAX_CONCURRENT_STREAMS",
+        ...         "INITIAL_WINDOW_SIZE",
+        ...         "MAX_HEADER_LIST_SIZE"
+        ...     ],
+        ...     "headerPriority": None,
+        ...     "ja3String": "771,2570-4865-4866-4867-49195-49199-49196-49200-52393-52392-49171-49172-156-157-47-53,2570-0-23-65281-10-11-35-16-5-13-18-51-45-43-27-17513-2570-21,2570-29-23-24,0",
+        ...     "keyShareCurves": ["GREASE", "X25519"],
+        ...     "priorityFrames": [],
+        ...     "pseudoHeaderOrder": [
+        ...         ":method",
+        ...         ":authority",
+        ...         ":scheme",
+        ...         ":path"
+        ...     ],
+        ...     "supportedSignatureAlgorithms": [
+        ...         "ECDSAWithP256AndSHA256",
+        ...         "PSSWithSHA256",
+        ...         "PKCS1WithSHA256",
+        ...         "ECDSAWithP384AndSHA384",
+        ...         "PSSWithSHA384",
+        ...         "PKCS1WithSHA384",
+        ...         "PSSWithSHA512",
+        ...         "PKCS1WithSHA512"
+        ...     ],
+        ...     "supportedVersions": ["GREASE", "1.3", "1.2"]
+        ... }
+        >>> obj = CustomTLSClientConfig.from_kwargs(**kwargs)
+
+    """
+
+    alpnProtocols: List[str] = None
+    alpsProtocols: List[str] = None
+    certCompressionAlgo: str = None
+    connectionFlow: int = None
+    h2Settings: List[str] = None
+    h2SettingsOrder: List[str] = None
+    headerPriority: List[str] = None
+    ja3String: str = None
+    keyShareCurves: List[str] = None
+    priorityFrames: List[str] = None
+    pseudoHeaderOrder: List[str] = None
+    supportedSignatureAlgorithms: List[str] = None
+    supportedVersions: List[str] = None
+
+
+@dataclass
+class TLSConfig(_BaseConfig):
+    """TLS Configuration
+
+    The `TLSConfig` class provides a structured and flexible way to configure TLS-specific settings for HTTP requests.
+    It supports features like custom headers, cookie handling, proxy configuration, and advanced TLS options.
+
+    Methods:
+        to_dict(self) -> dict
+            Converts the TLS configuration object into a dictionary.
+
+        copy_with(self, **kwargs) -> "TLSConfig"
+            Creates a new `TLSConfig` object with updated properties.
+
+        from_kwargs(cls, **kwargs) -> "TLSConfig"
+            Creates a `TLSConfig` instance from keyword arguments.
+
+    Example:
+        Initialize a `TLSConfig` object using predefined or custom settings:
+
+        >>> from tls_requests.tls import TLSConfig
+        >>> kwargs = {
+        ...    "catchPanics": false,
+        ...    "certificatePinningHosts": {},
+        ...    "customTlsClient": {},
+        ...    "followRedirects": false,
+        ...    "forceHttp1": false,
+        ...    "headerOrder": [
+        ...        "accept",
+        ...        "user-agent",
+        ...        "accept-encoding",
+        ...        "accept-language"
+        ...    ],
+        ...    "headers": {
+        ...        "accept": "text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3;q=0.9",
+        ...        "user-agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/105.0.0.0 Safari/537.36",
+        ...        "accept-encoding": "gzip, deflate, br",
+        ...        "accept-language": "de-DE,de;q=0.9,en-US;q=0.8,en;q=0.7"
+        ...    },
+        ...    "insecureSkipVerify": false,
+        ...    "isByteRequest": false,
+        ...    "isRotatingProxy": false,
+        ...    "proxyUrl": "",
+        ...    "requestBody": "",
+        ...    "requestCookies": [
+        ...        {
+        ...            "_name": "foo",
+        ...            "value": "bar",
+        ...        },
+        ...        {
+        ...            "_name": "bar",
+        ...            "value": "foo",
+        ...        },
+        ...    ],
+        ...    "requestMethod": "GET",
+        ...    "requestUrl": "https://microsoft.com",
+        ...    "sessionId": "2my-session-id",
+        ...    "timeoutSeconds": 30,
+        ...    "tlsClientIdentifier": "chrome_120",
+        ...    "withDebug": false,
+        ...    "withDefaultCookieJar": false,
+        ...    "withRandomTLSExtensionOrder": false,
+        ...    "withoutCookieJar": false
+        ... }
+        ... >>> obj = TLSConfig.from_kwargs(**kwargs)
+    """
+
+    catchPanics: bool = False
+    certificatePinningHosts: Mapping[str, str] = field(default_factory=dict)
+    customTlsClient: Optional[CustomTLSClientConfig] = None
+    followRedirects: bool = False
+    forceHttp1: bool = False
+    headerOrder: List[str] = field(default_factory=list)
+    headers: Mapping[str, str] = field(default_factory=dict)
+    insecureSkipVerify: bool = False
+    isByteRequest: bool = False
+    isByteResponse: bool = True
+    isRotatingProxy: bool = False
+    proxyUrl: str = ""
+    requestBody: Union[str, bytes, bytearray, None] = None
+    requestCookies: List[TLSRequestCookiesConfig] = field(default_factory=list)
+    requestMethod: MethodTypes = None
+    requestUrl: Optional[str] = None
+    sessionId: str = field(default_factory=lambda: str(uuid.uuid4()))
+    timeoutSeconds: int = 30
+    tlsClientIdentifier: Optional[TLSIdentifierTypes] = DEFAULT_TLS_IDENTIFIER
+    withDebug: bool = False
+    withDefaultCookieJar: bool = False
+    withRandomTLSExtensionOrder: bool = True
+    withoutCookieJar: bool = False
+
+    def to_dict(self) -> dict:
+        """Converts the TLS configuration object into a dictionary."""
+
+        if self.customTlsClient:
+            self.tlsClientIdentifier = None
+
+        self.followRedirects = False
+        if self.requestBody and isinstance(self.requestBody, (bytes, bytearray)):
+            self.isByteRequest = True
+            self.requestBody = to_base64(self.requestBody)
+        else:
+            self.isByteRequest = False
+            self.requestBody = None
+
+        self.timeoutSeconds = (
+            int(self.timeoutSeconds) if isinstance(self.timeoutSeconds, (float, int)) else DEFAULT_TIMEOUT
+        )
+        return asdict(self)
+
+    def copy_with(
+        self,
+        session_id: str = None,
+        headers: Mapping[str, str] = None,
+        cookies: TLSCookiesTypes = None,
+        method: MethodTypes = None,
+        url: URLTypes = None,
+        body: Union[str, bytes, bytearray] = None,
+        is_byte_request: bool = None,
+        proxy: str = None,
+        http2: bool = None,
+        timeout: Union[float, int] = None,
+        verify: bool = None,
+        tls_identifier: Optional[TLSIdentifierTypes] = None,
+        tls_debug: bool = None,
+        **kwargs,
+    ) -> "TLSConfig":
+        """Creates a new `TLSConfig` object with updated properties."""
+
+        kwargs.update(
+            dict(
+                sessionId=session_id,
+                headers=headers,
+                requestCookies=cookies,
+                requestMethod=method,
+                requestUrl=url,
+                requestBody=body,
+                isByteRequest=is_byte_request,
+                proxyUrl=proxy,
+                forceHttp1=not http2,
+                timeoutSeconds=timeout,
+                insecureSkipVerify=not verify,
+                tlsClientIdentifier=tls_identifier,
+                withDebug=tls_debug,
+            )
+        )
+        current_kwargs = asdict(self)
+        for k, v in current_kwargs.items():
+            if kwargs.get(k) is not None:
+                current_kwargs[k] = kwargs[k]
+
+        return self.__class__(**current_kwargs)  # noqa
+
+    @classmethod
+    def from_kwargs(
+        cls,
+        session_id: str = None,
+        headers: Mapping[str, str] = None,
+        cookies: TLSCookiesTypes = None,
+        method: MethodTypes = None,
+        url: URLTypes = None,
+        body: Union[str, bytes, bytearray] = None,
+        is_byte_request: bool = False,
+        proxy: str = None,
+        http2: bool = DEFAULT_TLS_HTTP2,
+        timeout: Union[float, int] = DEFAULT_TIMEOUT,
+        verify: bool = True,
+        tls_identifier: Optional[TLSIdentifierTypes] = DEFAULT_TLS_IDENTIFIER,
+        tls_debug: bool = DEFAULT_TLS_DEBUG,
+        **kwargs: Any,
+    ) -> "TLSConfig":
+        """Creates a `TLSConfig` instance from keyword arguments."""
+
+        kwargs.update(
+            dict(
+                sessionId=session_id,
+                headers=dict(headers) if headers else DEFAULT_HEADERS,
+                requestCookies=cookies or [],
+                requestMethod=method,
+                requestUrl=url,
+                requestBody=body,
+                isByteRequest=is_byte_request,
+                proxyUrl=proxy,
+                forceHttp1=bool(not http2),
+                timeoutSeconds=(int(timeout) if isinstance(timeout, (float, int)) else DEFAULT_TIMEOUT),
+                insecureSkipVerify=not verify,
+                tlsClientIdentifier=tls_identifier,
+                withDebug=tls_debug,
+            )
+        )
+        return super().from_kwargs(**kwargs)

--- a/vendor/tls_requests/models/urls.py
+++ b/vendor/tls_requests/models/urls.py
@@ -1,0 +1,663 @@
+from __future__ import annotations
+
+import time
+from collections.abc import Mapping
+from typing import Any, ItemsView, KeysView, Union, ValuesView
+from urllib.parse import ParseResult, quote, unquote, urlencode, urlparse
+
+import idna
+
+from ..exceptions import ProxyError, URLError, URLParamsError
+from ..types import URL_ALLOWED_PARAMS, ProxyTypes, URLParamTypes, URLTypes
+
+__all__ = ["URL", "URLParams", "Proxy"]
+
+
+class URLParams(Mapping):
+    """
+    A mapping-like object for managing URL query parameters.
+
+    This class provides a dictionary-like interface for URL parameters,
+    handling the normalization of keys and values into the correct string format
+    and encoding them into a query string. It supports multi-value parameters.
+
+    Attributes:
+        params (str): The URL-encoded query string representation of the parameters.
+
+    Examples:
+        >>> params = URLParams({'key1': 'value1', 'key2': ['value2', 'value3']})
+        >>> print(str(params))
+        'key1=value1&key2=value2&key2=value3'
+
+        >>> params.update({'key3': 4, 'active': True})
+        >>> print(params)
+        'key1=value1&key2=value2&key2=value3&key3=4&active=true'
+
+        >>> 'key1' in params
+        True
+    """
+
+    def __init__(self, params: URLParamTypes = None, **kwargs):
+        """
+        Initializes the URLParams object.
+
+        Args:
+            params: A dictionary, another URLParams instance, or a list of tuples
+                    to initialize the parameters.
+            **kwargs: Additional key-value pairs to add or overwrite parameters.
+
+        Raises:
+            URLParamsError: If `params` is not a valid mapping type.
+        """
+        self._data = self._prepare(params, **kwargs)
+
+    @property
+    def params(self) -> str:
+        """Returns the encoded URL parameters as a query string."""
+        return str(self)
+
+    def update(self, params: URLParamTypes = None, **kwargs):
+        """
+        Updates the current parameters with new ones from a mapping or keyword args.
+
+        Args:
+            params: A dictionary-like object of parameters to add.
+            **kwargs: Additional key-value pairs to add.
+        """
+        self._data.update(self._prepare(params, **kwargs))
+        return self
+
+    def keys(self) -> KeysView:
+        """Returns a view of the parameter keys."""
+        return self._data.keys()
+
+    def values(self) -> ValuesView:
+        """Returns a view of the parameter values."""
+        return self._data.values()
+
+    def items(self) -> ItemsView:
+        """Returns a view of the parameter key-value pairs."""
+        return self._data.items()
+
+    def copy(self) -> URLParams:
+        """Returns a shallow copy of the current instance."""
+        return self.__class__(self._data.copy())
+
+    def __str__(self):
+        """Returns the URL-encoded string representation of the parameters."""
+        return urlencode(self._data, doseq=True)
+
+    def __repr__(self):
+        """Returns the official string representation of the object."""
+        return "<%s: %s>" % (self.__class__.__name__, self.items())
+
+    def __contains__(self, key: Any) -> bool:
+        """Checks if a key exists in the parameters."""
+        return key in self._data
+
+    def __setitem__(self, key, value):
+        """Sets a parameter key-value pair, normalizing the input."""
+        self._data.update(self._prepare({key: value}))
+
+    def __getitem__(self, key):
+        """Retrieves a parameter value by its key."""
+        return self._data[key]
+
+    def __delitem__(self, key):
+        """Deletes a parameter by its key."""
+        del self._data[key]
+
+    def __iter__(self):
+        """Returns an iterator over the parameter keys."""
+        return (k for k in self.keys())
+
+    def __len__(self) -> int:
+        """Returns the number of unique parameter keys."""
+        return len(self._data)
+
+    def __hash__(self) -> int:
+        """Returns the hash of the encoded parameter string."""
+        return hash(str(self))
+
+    def __eq__(self, other) -> bool:
+        """Checks for equality based on the encoded parameter string."""
+        if not isinstance(other, self.__class__):
+            if isinstance(other, Mapping):
+                other = self.__class__(other)
+            else:
+                return False
+        return bool(self.params == other.params)
+
+    def _prepare(self, params: URLParamTypes = None, **kwargs) -> Mapping:
+        """
+        Normalizes and prepares the input parameters.
+
+        Args:
+            params: A dictionary-like object of parameters.
+            **kwargs: Additional keyword arguments.
+
+        Returns:
+            A mapping with normalized keys and values.
+
+        Raises:
+            URLParamsError: If keys or values are of an invalid type.
+        """
+        params = params or {}
+        if not isinstance(params, (dict, self.__class__)):
+            raise URLParamsError("Invalid parameters.")
+
+        params.update(kwargs)
+        for k, v in params.items():
+            if not isinstance(k, (str, bytes)):
+                raise URLParamsError("Invalid parameters key type.")
+
+            if isinstance(v, (list, tuple, set)):
+                v = [self.normalize(s) for s in v]
+            else:
+                v = self.normalize(v)
+
+            params[self.normalize(k)] = v
+        return params
+
+    def normalize(self, s: URL_ALLOWED_PARAMS):
+        """
+        Converts a supported type into a string.
+
+        Args:
+            s: The value to normalize (str, bytes, int, float, bool).
+
+        Returns:
+            The normalized string value.
+
+        Raises:
+            URLParamsError: If the value type is not supported.
+        """
+        if not isinstance(s, (str, bytes, int, float, bool)):
+            raise URLParamsError("Invalid parameters value type.")
+
+        if isinstance(s, bool):
+            return str(s).lower()
+
+        if isinstance(s, bytes):
+            return s.decode("utf-8")
+
+        return str(s)
+
+
+class URL:
+    """
+    A class for parsing, manipulating, and constructing URLs.
+
+    This class provides a structured way to interact with URL components,
+    integrating with `URLParams` for easy query string management. It handles
+    IDNA encoding for hostnames and ensures proper URL construction.
+
+    Attributes:
+        url (str): The full URL string. Can be set to re-parse.
+        params (URLParams): An object managing the URL's query parameters.
+        parsed (ParseResult): The result from `urllib.parse.urlparse`.
+        scheme (str): The URL scheme (e.g., "https").
+        netloc (str): The network location part (e.g., "user:pass@host:port").
+        host (str): The hostname, IDNA-encoded.
+        port (str): The port number as a string, if present.
+        path (str): The hierarchical path.
+        query (str): The complete query string, combining original and added params.
+        fragment (str): The fragment identifier.
+        username (str): The username for authentication.
+        password (str): The password for authentication.
+        auth (tuple): A (username, password) tuple.
+
+    Examples:
+        >>> url = URL("https://example.com/path?q=1#fragment", params={"key": "value"})
+        >>> print(url.scheme)
+        'https'
+        >>> print(url.host)
+        'example.com'
+        >>> print(url.query)
+        'q=1&key=value'
+
+        >>> url.params.update({'key2': 'value2'})
+        >>> print(unquote(url.url))
+        'https://example.com/path?q=1&key=value&key2=value2#fragment'
+
+        >>> url.url = 'https://httpbin.org/get'
+        >>> print(unquote(url.url))
+        'https://httpbin.org/get?key=value&key2=value2'
+    """
+
+    __attrs__ = (
+        "auth",
+        "scheme",
+        "host",
+        "port",
+        "path",
+        "fragment",
+        "username",
+        "password",
+    )
+
+    def __init__(self, url: URLTypes, params: URLParamTypes = None, **kwargs):
+        """
+        Initializes the URL object.
+
+        Args:
+            url: The URL string, bytes, or another URL object.
+            params: A dictionary-like object to be used as query parameters.
+            **kwargs: Additional keyword arguments for URLParams.
+
+        Raises:
+            URLError: If the provided URL is invalid.
+        """
+        self._parsed = self._prepare(url)
+        self._url = None
+        self._params = URLParams(params)
+
+    @property
+    def url(self):
+        """The full, reconstructed URL string."""
+        if self._url is None:
+            self._url = self._build(False)
+        return self._url
+
+    @url.setter
+    def url(self, value):
+        """Allows setting a new URL, which will be parsed."""
+        self._parsed = self._prepare(value)
+        self._url = self._build(False)
+
+    @property
+    def params(self):
+        """The `URLParams` object for managing query parameters."""
+        return self._params
+
+    @params.setter
+    def params(self, value):
+        """Sets a new `URLParams` object."""
+        self._url = None
+        self._params = URLParams(value)
+
+    @property
+    def parsed(self) -> ParseResult:
+        """The `ParseResult` object from the standard library."""
+        return self._parsed
+
+    @property
+    def netloc(self) -> str:
+        """The network location, including host and port."""
+        return ":".join([self.host, self.port]) if self.port else self.host
+
+    @property
+    def query(self) -> str:
+        """The combined query string from the original URL and the `params`."""
+        query = ""
+        if self.parsed.query and self.params.params:
+            query = "&".join([quote(self.parsed.query), self.params.params])
+        elif self.params.params:
+            query = self.params.params
+        elif self.parsed.query:
+            query = self.parsed.query
+        return query
+
+    def __str__(self):
+        """Returns the full URL string with the real password."""
+        return self._build()
+
+    def __repr__(self):
+        """Returns a representation of the URL with a secured password."""
+        return "<%s: %s>" % (self.__class__.__name__, unquote(self._build(True)))
+
+    def _prepare(self, url: Union[T, str, bytes]) -> ParseResult:
+        """
+        Validates, decodes, and parses the input URL.
+
+        Args:
+            url: The URL to prepare.
+
+        Returns:
+            A `ParseResult` object.
+
+        Raises:
+            URLError: For invalid URL types or formats.
+        """
+        if isinstance(url, bytes):
+            url = url.decode("utf-8")
+        elif isinstance(url, self.__class__) or issubclass(self.__class__, url.__class__):
+            url = str(url)
+
+        if not isinstance(url, str):
+            raise URLError("Invalid URL: %s" % url)
+
+        for attr in self.__attrs__:
+            setattr(self, attr, None)
+
+        parsed = urlparse(url.lstrip())
+
+        self.auth = parsed.username, parsed.password
+        self.scheme = parsed.scheme
+
+        try:
+            self.host = idna.encode(parsed.hostname.lower()).decode("ascii")
+        except AttributeError:
+            self.host = ""
+        except idna.IDNAError:
+            raise URLError("Invalid IDNA hostname.")
+
+        self.port = ""
+        try:
+            if parsed.port:
+                self.port = str(parsed.port)
+        except ValueError as e:
+            raise URLError("%s. port range must be 0 - 65535." % e.args[0])
+
+        self.path = parsed.path
+        self.fragment = parsed.fragment
+        self.username = parsed.username or ""
+        self.password = parsed.password or ""
+        return parsed
+
+    def _build(self, secure: bool = False) -> str:
+        """
+        Constructs the URL string from its components.
+
+        Args:
+            secure: If True, masks the password in the output.
+
+        Returns:
+            The final URL string.
+        """
+        urls = [self.scheme, "://"]
+        authority = self.netloc
+        if self.username or self.password:
+            password = self.password or ""
+            if secure:
+                password = "[secure]"
+
+            authority = "@".join(
+                [
+                    ":".join([self.username, password]),
+                    self.netloc,
+                ]
+            )
+
+        urls.append(authority)
+        if self.query:
+            urls.append("?".join([self.path, self.query]))
+        else:
+            urls.append(self.path)
+
+        if self.fragment:
+            urls.append("#" + self.fragment)
+
+        return "".join(urls)
+
+
+class Proxy(URL):
+    """
+    A specialized URL class for managing proxy configurations and performance.
+
+    This class inherits from `URL` and extends it with features for proxy
+    rotation strategies, such as weighting, success/failure tracking, and
+    metadata. It restricts the allowed URL schemes to those common for proxies.
+
+    Attributes:
+        ALLOWED_SCHEMES (tuple): Allowed proxy schemes ('http', 'https', 'socks5', 'socks5h').
+        weight (float): The weight of the proxy, used in selection algorithms.
+        region (Optional[str]): A geographical or logical region identifier.
+        latency (Optional[float]): The last recorded latency in seconds.
+        success_rate (Optional[float]): A score indicating reliability (0.0 to 1.0).
+        meta (Dict[str, Any]): A dictionary for arbitrary user-defined data.
+        failures (int): A counter for consecutive connection failures.
+        last_used (Optional[float]): A timestamp of the last time the proxy was used.
+
+    Examples:
+        >>> proxy = Proxy("http://user:pass@127.0.0.1:8080", weight=5.0, region="us-east")
+        >>> proxy.mark_failed()
+        >>> print(proxy.failures)
+        1
+        >>> print(proxy.weight)
+        4.25
+        >>> proxy.mark_success()
+        >>> data = proxy.to_dict()
+        >>> print(data['url'])
+        'http://user:pass@127.0.0.1:8080'
+    """
+
+    ALLOWED_SCHEMES = ("http", "https", "socks5", "socks5h")
+
+    def __init__(
+        self,
+        url: URLTypes,
+        params: URLParamTypes = None,
+        *,
+        weight: float = 1.0,
+        region: Optional[str] = None,
+        latency: Optional[float] = None,
+        success_rate: Optional[float] = None,
+        meta: Optional[Dict[str, Any]] = None,
+        **kwargs,
+    ):
+        """
+        Initializes the Proxy object.
+
+        Args:
+            url: The proxy URL string, bytes, or another URL object.
+            params: URL parameters (rarely used for proxies).
+            weight: The initial weight for proxy selection (higher is more likely).
+            region: An identifier for the proxy's region.
+            latency: The initial or last known latency in seconds.
+            success_rate: A score from 0.0 to 1.0 indicating reliability.
+            meta: A dictionary for storing arbitrary user data.
+            **kwargs: Additional keyword arguments passed to the parent `URL` class.
+
+        Raises:
+            ProxyError: If the URL is invalid or the scheme is not supported.
+        """
+        self._weight = weight or 1.0
+        self.region = region
+        self.latency = latency
+        self.success_rate = success_rate
+        self.meta = meta or {}
+        self.failures: int = 0
+        self.last_used: Optional[float] = None
+        super().__init__(url, **kwargs)
+
+    def __repr__(self):
+        """Returns a secure representation of the proxy with its weight."""
+        return "<%s: %s, weight=%s>" % (
+            self.__class__.__name__,
+            unquote(self._build(True)),
+            getattr(self, "weight", "unset"),
+        )
+
+    @property
+    def weight(self) -> float:
+        return self._weight or 1.0
+
+    @weight.setter
+    def weight(self, weight: float) -> None:
+        try:
+            self._weight = float(weight)
+        except ValueError:
+            raise ProxyError("Weight must be an integer or float.")
+
+    def _prepare(self, url: ProxyTypes) -> ParseResult:
+        """
+        Parses the proxy URL, ensuring it has a valid scheme and format.
+
+        Overrides the parent `_prepare` to enforce proxy-specific rules.
+
+        Args:
+            url: The proxy URL to prepare.
+
+        Returns:
+            A `ParseResult` object containing only scheme and netloc.
+
+        Raises:
+            ProxyError: If the URL is invalid or the scheme is not allowed.
+        """
+        try:
+            if isinstance(url, bytes):
+                url = url.decode("utf-8")
+
+            if isinstance(url, str):
+                url = url.strip()
+
+            if "://" not in str(url):
+                url = f"http://{url}"
+
+            parsed = super(Proxy, self)._prepare(url)
+            if str(parsed.scheme).lower() not in self.ALLOWED_SCHEMES:
+                raise ProxyError(
+                    "Invalid proxy scheme `%s`. The allowed schemes are ('http', 'https', 'socks5', 'socks5h')."
+                    % parsed.scheme
+                )
+
+            # Re-parse to create a clean object with only scheme and netloc
+            return urlparse("%s://%s" % (parsed.scheme, parsed.netloc))
+        except URLError:
+            raise ProxyError("Invalid proxy: %s" % url)
+
+    def _build(self, secure: bool = False) -> str:
+        """
+        Constructs the proxy URL string.
+
+        Overrides the parent `_build` to exclude path, query, and fragment.
+
+        Args:
+            secure: If True, masks the password.
+
+        Returns:
+            The proxy URL string.
+        """
+        urls = [self.scheme or "http", "://"]
+        authority = self.netloc
+        if self.username or self.password:
+            userinfo = ":".join([self.username, self.password])
+            if secure:
+                userinfo = "[secure]"
+
+            authority = "@".join(
+                [
+                    userinfo,
+                    self.netloc,
+                ]
+            )
+
+        urls.append(authority)
+        return "".join(urls)
+
+    def mark_used(self):
+        """Sets the `last_used` timestamp to the current time."""
+        self.last_used = time.time()
+
+    def mark_failed(self):
+        """
+        Records a connection failure.
+
+        Increments the failure count and applies a decay factor to the weight.
+        """
+        self.failures += 1
+        self.weight = max(0.1, self.weight * 0.85)
+
+    def mark_success(self, latency: Optional[float] = None):
+        """
+        Records a connection success.
+
+        Resets failure count, updates latency, and improves success rate and weight.
+
+        Args:
+            latency: The observed connection latency in seconds for this success.
+        """
+        if latency:
+            self.latency = latency
+
+        self.failures = max(0, self.failures - 1)
+        self.success_rate = (self.success_rate or 1.0) * 0.95 + 0.05
+        self.weight = min(10.0, self.weight * 1.05)
+
+    def to_dict(self):
+        """
+        Serializes the proxy's state to a dictionary.
+
+        Returns:
+            A dictionary containing the proxy's URL and performance metrics.
+        """
+        return {
+            "url": self.url,
+            "weight": self.weight,
+            "region": self.region,
+            "latency": self.latency,
+            "success_rate": self.success_rate,
+            "last_used": self.last_used,
+        }
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> "Proxy":
+        """
+        Creates a Proxy object from a dictionary.
+
+        Args:
+            data: A dictionary containing a 'url' key and other optional
+                  proxy attributes (`weight`, `region`, etc.).
+
+        Returns:
+            A new `Proxy` instance.
+
+        Raises:
+            ProxyError: If the 'url' key is missing from the dictionary.
+        """
+        if "url" not in data:
+            raise ProxyError("Missing required key: 'url'. The proxy configuration dictionary must include a 'url'.")
+
+        url = data.pop("url")
+        return cls(
+            url=url,
+            **data,
+        )
+
+    @classmethod
+    def from_string(cls, raw: str, separator: str = "|") -> "Proxy":
+        """
+        Parses a proxy from a string with optional attributes.
+
+        Handles various common formats for representing proxies in text files.
+        Comments (#) and blank lines should be handled by the calling code.
+
+        Supported Formats:
+          - `http://user:pass@host:port`
+          - `socks5://host:port`
+          - `host:port` (defaults to http)
+          - `host:port|weight`
+          - `host:port|weight|region`
+          - `http://user:pass@host:port|weight|region`
+
+        Args:
+            raw: The raw proxy string.
+            separator: The character used to separate attributes (default: '|').
+
+        Returns:
+            A new `Proxy` instance.
+
+        Raises:
+            ProxyError: If the proxy string is empty or malformed.
+        """
+        raw = raw.strip()
+        if not raw:
+            raise ProxyError("Empty proxy string.")
+
+        parts = [p.strip() for p in raw.split(separator)]
+        url = parts[0]
+        weight = 1.0
+        region = None
+        if len(parts) >= 2 and parts[1]:
+            try:
+                weight = float(parts[1])
+            except Exception:
+                pass
+        if len(parts) >= 3 and parts[2]:
+            region = parts[2]
+
+        if "://" not in url:
+            url = "http://" + url
+
+        return cls(url, weight=weight, region=region)

--- a/vendor/tls_requests/settings.py
+++ b/vendor/tls_requests/settings.py
@@ -1,0 +1,18 @@
+from __future__ import annotations
+
+from .__version__ import __version__
+
+CHUNK_SIZE = 65_536
+DEFAULT_TIMEOUT = 30.0
+DEFAULT_MAX_REDIRECTS = 9
+DEFAULT_FOLLOW_REDIRECTS = True
+DEFAULT_TLS_DEBUG = False
+DEFAULT_TLS_INSECURE_SKIP_VERIFY = False
+DEFAULT_TLS_HTTP2 = "auto"
+DEFAULT_TLS_IDENTIFIER = "chrome_133"
+DEFAULT_HEADERS = {
+    "accept": "*/*",
+    "connection": "keep-alive",
+    "user-agent": f"Python-TLS-Requests/{__version__}",
+    "accept-encoding": "gzip, deflate, br, zstd",
+}

--- a/vendor/tls_requests/types.py
+++ b/vendor/tls_requests/types.py
@@ -1,0 +1,163 @@
+"""
+Type definitions for type checking purposes.
+"""
+
+from http.cookiejar import CookieJar
+from typing import (IO, TYPE_CHECKING, Any, BinaryIO, Callable, Dict, List,
+                    Literal, Mapping, Optional, Sequence, Set, Tuple, Union)
+from uuid import UUID
+
+if TYPE_CHECKING:  # pragma: no cover
+    from .models import Headers  # noqa: F401
+    from .models import (Cookies, HeaderRotator, ProxyRotator,
+                         TLSIdentifierRotator)
+
+AuthTypes = Optional[
+    Union[
+        Tuple[Union[str, bytes], Union[str, bytes]],
+        Callable,
+        "Auth",
+        "BasicAuth",
+    ]
+]
+URLTypes = Union["URL", str, bytes]
+ProxyTypes = Union[str, bytes, "Proxy", "URL", "ProxyRotator"]
+URL_ALLOWED_PARAMS = Union[str, bytes, int, float, bool]
+URLParamTypes = Optional[
+    Union[
+        "URLParams",
+        Mapping[
+            Union[str, bytes],
+            Union[
+                URL_ALLOWED_PARAMS,
+                List[URL_ALLOWED_PARAMS],
+                Tuple[URL_ALLOWED_PARAMS],
+                Set[URL_ALLOWED_PARAMS],
+            ],
+        ],
+    ]
+]
+MethodTypes = Union["Method", Literal["GET", "OPTIONS", "HEAD", "POST", "PUT", "PATCH", "DELETE"]]
+ProtocolTypes = Optional[Union[Literal["auto", "http1", "http2"], bool]]
+HookTypes = Optional[Mapping[Literal["request", "response"], Sequence[Callable]]]
+TLSSession = Union["TLSSession", None]
+TLSSessionId = Union[str, UUID]
+TLSPayload = Union[dict, str, bytes, bytearray]
+TLSCookiesTypes = Optional[List[Dict[str, str]]]
+TLSIdentifierTypes = Union[
+    Literal[
+        "chrome_103",
+        "chrome_104",
+        "chrome_105",
+        "chrome_106",
+        "chrome_107",
+        "chrome_108",
+        "chrome_109",
+        "chrome_110",
+        "chrome_111",
+        "chrome_112",
+        "chrome_116_PSK",
+        "chrome_116_PSK_PQ",
+        "chrome_117",
+        "chrome_120",
+        "chrome_124",
+        "chrome_130_PSK",
+        "chrome_131",
+        "chrome_131_PSK",
+        "chrome_133",
+        "chrome_133_PSK",
+        "confirmed_android",
+        "confirmed_android_2",
+        "confirmed_ios",
+        "firefox_102",
+        "firefox_104",
+        "firefox_105",
+        "firefox_106",
+        "firefox_108",
+        "firefox_110",
+        "firefox_117",
+        "firefox_120",
+        "firefox_123",
+        "firefox_132",
+        "firefox_133",
+        "mesh_android",
+        "mesh_android_1",
+        "mesh_android_2",
+        "mesh_ios",
+        "mesh_ios_1",
+        "mesh_ios_2",
+        "mms_ios",
+        "mms_ios_1",
+        "mms_ios_2",
+        "mms_ios_3",
+        "nike_android_mobile",
+        "nike_ios_mobile",
+        "okhttp4_android_10",
+        "okhttp4_android_11",
+        "okhttp4_android_12",
+        "okhttp4_android_13",
+        "okhttp4_android_7",
+        "okhttp4_android_8",
+        "okhttp4_android_9",
+        "opera_89",
+        "opera_90",
+        "opera_91",
+        "safari_15_6_1",
+        "safari_16_0",
+        "safari_ipad_15_6",
+        "safari_ios_15_5",
+        "safari_ios_15_6",
+        "safari_ios_16_0",
+        "safari_ios_17_0",
+        "safari_ios_18_0",
+        "safari_ios_18_5",
+        "zalando_android_mobile",
+        "zalando_ios_mobile",
+    ],
+    "TLSIdentifierRotator",
+]
+
+AnyList = List[
+    Union[
+        List[Union[str, Union[str, int, float]]],
+        Tuple[Union[str, Union[str, int, float]]],
+        Set[Union[str, Union[str, int, float]]],
+        List[Union[str, bytes]],
+        Tuple[Union[str, bytes]],
+        Set[Union[str, bytes]],
+    ]
+]
+
+HeaderTypes = Optional[
+    Union[
+        "Headers",
+        "HeaderRotator",
+        Mapping[str, Union[str, int, float]],
+        Mapping[bytes, bytes],
+        AnyList,
+    ]
+]
+
+CookieTypes = Optional[
+    Union[
+        "Cookies",
+        CookieJar,
+        Mapping[str, Union[str, int, float]],
+        Mapping[bytes, bytes],
+        AnyList,
+    ]
+]
+
+TimeoutTypes = Optional[Union[int, float]]
+ByteOrStr = Union[bytes, str]
+BufferTypes = Union[IO[bytes], "BytesIO", "BufferedReader"]
+FileContent = Union[ByteOrStr, BinaryIO]
+RequestFileValue = Union[
+    FileContent,  # file (or file path, str and bytes)
+    Tuple[ByteOrStr, FileContent],  # filename, file (or file path, str and bytes))
+    Tuple[ByteOrStr, FileContent, ByteOrStr],  # filename, file (or file path, str and bytes)), content type
+]
+RequestData = Mapping[str, Any]
+RequestJson = Mapping[str, Any]
+RequestFiles = Mapping[ByteOrStr, RequestFileValue]
+ResponseHistory = List["Response"]

--- a/vendor/tls_requests/utils.py
+++ b/vendor/tls_requests/utils.py
@@ -1,0 +1,110 @@
+from __future__ import annotations
+
+import base64
+import importlib
+import logging
+from typing import Any, AnyStr, Union
+
+FORMAT = "[%(asctime)s] %(levelname)-8s %(name)s:%(funcName)s:%(lineno)d - %(message)s"
+DATE_FORMAT = "%Y-%m-%d %H:%M:%S"
+
+
+def import_module(name: Union[str, list[str]]):
+    modules = name if isinstance(name, list) else [name]
+    for module in modules:
+        if isinstance(module, str):
+            try:
+                module = importlib.import_module(module)
+                return module
+            except ImportError:
+                pass
+
+
+chardet = import_module(["chardet", "charset_normalizer"])
+orjson = import_module(["orjson"])
+if orjson:
+    jsonlib = orjson
+else:
+    import json
+
+    jsonlib = json
+
+
+def get_logger(
+    name: str = "TLSRequests", level: int | str = logging.INFO
+) -> logging.Logger:
+    logger = logging.getLogger(name)
+    logger.setLevel(level)
+
+    if not logger.handlers:
+        handler = logging.StreamHandler()
+        formatter = logging.Formatter(FORMAT, datefmt=DATE_FORMAT)
+        handler.setFormatter(formatter)
+        logger.addHandler(handler)
+
+    return logger
+
+
+def to_bytes(value: Any, encoding: str = "utf-8", *, lower: bool = False) -> bytes:
+    if isinstance(value, (bytes, bytearray)):
+        return value
+    return to_str(value, encoding).encode(encoding)
+
+
+def to_str(
+    value: Any,
+    encoding: str = "utf-8",
+    *,
+    lower: bool = False,
+) -> str:
+    if value is None:
+        return ""
+
+    value = value.decode(encoding) if isinstance(value, (bytes, bytearray)) else value
+    if isinstance(value, (dict, list, tuple, set)):
+        value = json_dumps(
+            value if isinstance(value, dict) else list[value],
+            **dict(
+                ensure_ascii=True if str(encoding).lower() == "ascii" else False,
+                default=str,
+            ),
+        )
+
+    if isinstance(value, bool):
+        lower = True
+
+    if lower:
+        return str(value).lower()
+
+    return str(value)
+
+
+def to_base64(value: Union[dict, str, bytes], encoding: str = "utf-8") -> AnyStr:
+    return base64.b64encode(to_bytes(value, encoding)).decode(encoding)
+
+
+def b64decode(value: AnyStr) -> bytes:
+    return base64.b64decode(value)
+
+
+def to_json(value: Union[str, bytes], encoding: str = "utf-8", **kwargs) -> dict:
+    if isinstance(value, dict):
+        return value
+    try:
+        json_data = jsonlib.loads(value, **kwargs)
+        return json_data
+    except jsonlib.JSONDecodeError:
+        raise jsonlib.JSONDecodeError
+
+
+def json_dumps(value, **kwargs) -> str:
+    try:
+        if orjson:
+            kwargs = {"default": kwargs.pop("default", None)}
+
+        json_data = jsonlib.dumps(value, **kwargs)
+        if isinstance(json_data, bytes):
+            json_data = json_data.decode("utf-8")
+        return json_data
+    except jsonlib.JSONDecodeError:
+        raise jsonlib.JSONDecodeError


### PR DESCRIPTION
Updated `__init__.py` to use `tls_requests` for HTTP requests instead of just `requests` (as it always triggers captcha), to reduce complete reliance on proxy (to reduce proxy usage/strain), and improve add-on reliability. Vendors `tls_requests`.